### PR TITLE
Set lower log level when loading an XML resource

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/resource/XMLResource.java
@@ -118,7 +118,7 @@ public class XMLResource extends AbstractResource {
                     "property, which is set to: " + System.getProperty("javax.xml.parsers.SAXParserFactory"));
         }
 
-        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_SAX_XMLREADER_IN_USE, xmlReader.getClass().getName());
+        XRLog.log(Level.FINEST, LogMessageId.LogMessageId1Param.LOAD_SAX_XMLREADER_IN_USE, xmlReader.getClass().getName());
 
         return xmlReader;
     }
@@ -274,7 +274,7 @@ public class XMLResource extends AbstractResource {
 
             target.setElapsedLoadTime(end - st);
 
-            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_LOADED_DOCUMENT_TIME, target.getElapsedLoadTime());
+            XRLog.log(Level.FINEST, LogMessageId.LogMessageId1Param.LOAD_LOADED_DOCUMENT_TIME, target.getElapsedLoadTime());
 
             target.setDocument((Document) output.getNode());
             return target;


### PR DESCRIPTION
We are generating PDFs which include many external SVG files using `<img src="xyz.svg"/>`.
Following two log lines are repeated for **every** loaded SVG, which in our case results with more than 5000 uninformative log messages per PDF:
```
2024-01-28T16:39:26.411+01:00  INFO 11121 --- [nio-8080-exec-7] com.openhtmltopdf.load                   : SAX XMLReader in use (parser): com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser
2024-01-28T16:39:26.411+01:00  INFO 11121 --- [nio-8080-exec-7] com.openhtmltopdf.load                   : Loaded document in ~0ms
```

I believe log level can be lowered from INFO to FINEST since these messages can be quite invasive. LMKWYT :eyes: 