### PR TITLE
Updates to the GitHub Actions workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK ${{matrix.java}}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: ${{matrix.java}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 
 name: build
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,13 +20,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: ${{matrix.java}}
+        cache: maven
     - name: Maven -v
       run: mvn -v
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK ${{matrix.java}}
       uses: actions/setup-java@v4
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{matrix.java}}
     - name: Maven -v
       run: mvn -v

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,7 +14,7 @@ jobs:
         java: ['8','11','17', '21']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{matrix.java}}
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8','11','17']
+        java: ['8','11','17', '21']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Including
- Support for Java 21
- Newest versions of the actions used
- Switch to Eclipse Temurin as distro, as it tends to be included in the github runners, and hence faster
- Using the setup-java caching mechanism for maven instead of a separate action, for simplicity

Note: This PR also includes https://github.com/openhtmltopdf/openhtmltopdf/pull/6 , as it is needed for the build to run properly. I have activated actions on my fork, so you can see examples of this running at https://github.com/madsop-nav/openhtmltopdf/actions/runs/7695317933