### PR TITLE
Fine-tune GitHub Actions and versioning

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: 17
           cache: maven
       - name: Upload artifact
-        run: mvn -B deploy -Dgithub-release -e -Drevision=${{ github.sha }}
+        run: mvn -B deploy -Dgithub-release -e -Drevision=dev-${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: 17
           cache: maven
       - name: Upload artifact
-        run: mvn -B deploy -Dgithub-release -e
+        run: mvn -B deploy -Dgithub-release -e -Drevision=${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
@@ -74,7 +74,7 @@ jobs:
           java-version: 17
           cache: maven
       - name: Upload artifact
-        run: mvn -B deploy -Dgithub-release
+        run: mvn -B deploy -Dgithub-release -Drevision=${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,13 +48,6 @@ jobs:
         run: mvn -B deploy -Dgithub-release -e -Drevision=dev-${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create release
-        id: create_release
-        uses: elgohr/Github-Release-Action@v5
-        with:
-          title: openhtmltopdf.dev
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Create release

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target
 **/*.releaseBackup
 *.releaseBackup
 release.properties
+**/.flattened-pom.xml
 */.classpath
 */.project
 */.settings

--- a/openhtmltopdf-core/pom.xml
+++ b/openhtmltopdf-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-core</artifactId>

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-examples</artifactId>

--- a/openhtmltopdf-java2d/pom.xml
+++ b/openhtmltopdf-java2d/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-java2d</artifactId>

--- a/openhtmltopdf-latex-support/pom.xml
+++ b/openhtmltopdf-latex-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-latex-support</artifactId>

--- a/openhtmltopdf-mathml-support/pom.xml
+++ b/openhtmltopdf-mathml-support/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>at.datenwort.openhtmltopdf</groupId>
 		<artifactId>openhtmltopdf-parent</artifactId>
-		<version>1.1.5-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>openhtmltopdf-mathml-support</artifactId>

--- a/openhtmltopdf-objects/pom.xml
+++ b/openhtmltopdf-objects/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>at.datenwort.openhtmltopdf</groupId>
 		<artifactId>openhtmltopdf-parent</artifactId>
-		<version>1.1.5-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>openhtmltopdf-objects</artifactId>

--- a/openhtmltopdf-pdfa-testing/pom.xml
+++ b/openhtmltopdf-pdfa-testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-pdfa-testing</artifactId>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-pdfbox</artifactId>

--- a/openhtmltopdf-rtl-support/pom.xml
+++ b/openhtmltopdf-rtl-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-rtl-support</artifactId>

--- a/openhtmltopdf-slf4j/pom.xml
+++ b/openhtmltopdf-slf4j/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-slf4j</artifactId>

--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-svg-support</artifactId>

--- a/openhtmltopdf-templates/pom.xml
+++ b/openhtmltopdf-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>at.datenwort.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>openhtmltopdf-templates</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,30 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.6.0</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>at.datenwort.openhtmltopdf</groupId>
   <artifactId>openhtmltopdf-parent</artifactId>
-  <version>1.1.5-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <packaging>pom</packaging>
 
@@ -252,6 +252,7 @@
   </build>
 
   <properties>
+    <revision>1.1.5-SNAPSHOT</revision>
     <open.batik.version>1.17</open.batik.version>
 
     <!-- Please keep xmlgraphics-commons up to date with batik. -->


### PR DESCRIPTION
As it's now, the artifacts from the dev releases overwrite the properly released ones. Hence, we're switching to using the commit SHA as the artifact version and release version.

It's also unnecessary and confusing to create proper GitHub releases for the dev ones, where the point is merely to have the artifacts published and available for local downstream development.

I don't think we have landed a versioning scheme nor proper release process, so I'm not sure whether we should stick to using SHA version for the released versions, but that's more a part of the #13 discussion.

The flatten plugin is required for using this property-based versioning in a multi-module project. Without it, the version in the subproject won't be replaced with the property.