### PR TITLE
FIX ignored at-rule after unrecognized at-rule

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -224,7 +224,7 @@ public class CSSParser {
                         error(new CSSParseException(
                                 "Invalid at-rule", getCurrentLine()), "at-rule", true);
                         recover(false, false);
-                        // fall through
+                        break;
                     default:
                         ruleset(stylesheet);
                 }

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSParserTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSParserTest.java
@@ -1,0 +1,44 @@
+package com.openhtmltopdf.css.parser;
+
+import com.openhtmltopdf.css.sheet.PageRule;
+import com.openhtmltopdf.css.sheet.Stylesheet;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+
+public class CSSParserTest {
+
+    private final static CSSErrorHandler errorHandler = (uri, message) -> System.out.println(message);
+    private final static CSSParser parser = new CSSParser(errorHandler);
+    private final static String basePath = "/com/openhtmltopdf/css/parser/";
+
+    private static Stylesheet parseStylesheet(String fileName) {
+        String fullPath = basePath + fileName;
+        URL url = CSSParserTest.class.getResource(fullPath);
+        assert url != null;
+
+        try {
+            InputStream inputStream = Files.newInputStream(new File(url.toURI()).toPath());
+            return parser.parseStylesheet(url.toString(), 0, new InputStreamReader(inputStream));
+        } catch (IOException | URISyntaxException e) {
+            fail();
+            return new Stylesheet(null, 0);
+        }
+    }
+
+    @Test
+    public void unrecognized_at_rule() {
+        Stylesheet stylesheet = parseStylesheet("unrecognized_at_rule.css");
+        assertEquals(1, stylesheet.getContents().size());
+        assertTrue(stylesheet.getContents().get(0) instanceof PageRule);
+    }
+
+}

--- a/openhtmltopdf-core/src/test/resources/com/openhtmltopdf/css/parser/unrecognized_at_rule.css
+++ b/openhtmltopdf-core/src/test/resources/com/openhtmltopdf/css/parser/unrecognized_at_rule.css
@@ -1,0 +1,7 @@
+@invalid {
+    foo: 0;
+}
+
+@page {
+    size: letter landscape;
+}


### PR DESCRIPTION
STR: An unrecognized at-rule is followed by a second at-rule.

Because of a switch case fall-through, the second at-rule will be parsed as a typical "RuleSet", and will be ignored. Adding a break statement to the case allows the loop to continue and all switch cases to be re-evaluated for the next token rather than assuming the next token is a typical RuleSet.

Included is a passing unit test which fails when the break statement is missing.

I spent several hours rummaging through the code to find the bug, and in doing so, I added a bunch of comments, changed a couple log statements, and made some readability improvements. I'm going to open a second PR with these minimal changes. I want the bug fix PR to stand alone, so as to be simple and easy to quickly understand.