### PR TITLE
Miscellaneous changes following #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 **/**.iml
 *.ipr
 .idea
+.DS_Store
 dist
 target
 **/*.releaseBackup

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.css.newmatch.Matcher;
 import com.openhtmltopdf.css.sheet.FontFaceRule;
 import com.openhtmltopdf.util.LogMessageId;
 import org.w3c.dom.Document;
@@ -65,10 +66,10 @@ public class StyleReference {
      * Instance of our element-styles matching class. Will be null if new rules
      * have been added since last match.
      */
-    private com.openhtmltopdf.css.newmatch.Matcher _matcher;
+    private Matcher _matcher;
 
     private UserAgentCallback _uac;
-    
+
     public StyleReference(UserAgentCallback userAgent) {
         _uac = userAgent;
         _stylesheetFactory = new StylesheetFactoryImpl(userAgent);
@@ -97,43 +98,42 @@ public class StyleReference {
         _context = context;
         _nsh = nsh;
         _doc = doc;
-        AttributeResolver attRes = new StandardAttributeResolver(_nsh, _uac, ui);
 
         List<StylesheetInfo> infos = getStylesheets();
 
-        XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.MATCH_MEDIA_IS, _context.getMedia());
-        
-        _matcher = new com.openhtmltopdf.css.newmatch.Matcher(
-                new DOMTreeResolver(), 
-                attRes, 
-                _stylesheetFactory, 
-                readAndParseAll(infos, _context.getMedia()), 
+        XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.MATCH_MEDIA_IS, _context.getMedia());
+
+        _matcher = new Matcher(
+                new DOMTreeResolver(),
+                new StandardAttributeResolver(_nsh, _uac, ui),
+                _stylesheetFactory,
+                readAndParseAll(infos, _context.getMedia()),
                 _context.getMedia());
     }
-    
+
     private List<Stylesheet> readAndParseAll(List<StylesheetInfo> infos, String medium) {
         List<Stylesheet> result = new ArrayList<>(infos.size() + 15);
-        
+
         for (StylesheetInfo info : infos) {
             if (info.appliesToMedia(medium)) {
                 Stylesheet sheet = info.getStylesheet();
-                
+
                 if (sheet == null) {
                     sheet = _stylesheetFactory.getStylesheet(info);
                 }
-                
+
                 if (sheet != null) {
                     if (sheet.getImportRules().size() > 0) {
                         result.addAll(readAndParseAll(sheet.getImportRules(), medium));
                     }
-                    
+
                     result.add(sheet);
                 } else {
                     XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNABLE_TO_LOAD_CSS_FROM_URI, info.getUri());
                 }
             }
         }
-        
+
         return result;
     }
 
@@ -146,7 +146,7 @@ public class StyleReference {
      * assigned value as a SAC CSSValue instance. The properties should have
      * been matched to the element when the Context was established for this
      * StyleReference on the Document to which the Element belongs.
-     * 
+     *
      * Only used by broken DOM inspector.
      *
      * @param e The DOM Element for which to find properties
@@ -155,15 +155,15 @@ public class StyleReference {
     @Deprecated
 	public java.util.Map<String, CSSPrimitiveValue> getCascadedPropertiesMap(Element e) {
         CascadedStyle cs = _matcher.getCascadedStyle(e, false);
-        
+
 		java.util.Map<String, CSSPrimitiveValue> props = new java.util.LinkedHashMap<>();
-		
+
 		for (PropertyDeclaration pd : cs.getCascadedPropertyDeclarations()) {
             String propName = pd.getPropertyName();
             CSSName cssName = CSSName.getByPropertyName(propName);
             props.put(propName, cs.propertyByName(cssName).getValue());
         }
-		
+
         return props;
     }
 
@@ -255,12 +255,12 @@ public class StyleReference {
     public List<FontFaceRule> getFontFaceRules() {
         return _matcher.getFontFaceRules();
     }
-    
+
     public void setUserAgentCallback(UserAgentCallback userAgentCallback) {
         _uac = userAgentCallback;
         _stylesheetFactory.setUserAgentCallback(userAgentCallback);
     }
-    
+
     public void setSupportCMYKColors(boolean b) {
         _stylesheetFactory.setSupportCMYKColors(b);
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -112,26 +112,27 @@ public class StyleReference {
     }
 
     private List<Stylesheet> readAndParseAll(List<StylesheetInfo> infos, String medium) {
-        List<Stylesheet> result = new ArrayList<>(infos.size() + 15);
+        List<Stylesheet> result = new ArrayList<>(infos.size() * 2);
 
         for (StylesheetInfo info : infos) {
-            if (info.appliesToMedia(medium)) {
-                Stylesheet sheet = info.getStylesheet();
-
-                if (sheet == null) {
-                    sheet = _stylesheetFactory.getStylesheet(info);
-                }
-
-                if (sheet != null) {
-                    if (sheet.getImportRules().size() > 0) {
-                        result.addAll(readAndParseAll(sheet.getImportRules(), medium));
-                    }
-
-                    result.add(sheet);
-                } else {
-                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNABLE_TO_LOAD_CSS_FROM_URI, info.getUri());
-                }
+            if (!info.appliesToMedia(medium)) {
+                continue;
             }
+
+            Stylesheet sheet = info.getStylesheet();
+            if (sheet == null) {
+                sheet = _stylesheetFactory.getStylesheet(info);
+            }
+            if (sheet == null) {
+                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.LOAD_UNABLE_TO_LOAD_CSS_FROM_URI, info.getUri());
+                continue;
+            }
+
+            if (!sheet.getImportRules().isEmpty()) {
+                result.addAll(readAndParseAll(sheet.getImportRules(), medium));
+            }
+
+            result.add(sheet);
         }
 
         return result;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -227,24 +227,21 @@ public class StyleReference {
             infos.add(defaultStylesheet);
         }
 
-        StylesheetInfo[] refs = _nsh.getStylesheets(_doc);
+        StylesheetInfo[] stylesheetInfos = _nsh.getStylesheets(_doc);
         int inlineStyleCount = 0;
-        if (refs != null) {
-            for (StylesheetInfo ref : refs) {
-                String uri;
+        if (stylesheetInfos != null) {
+            for (StylesheetInfo stylesheetInfo : stylesheetInfos) {
+                if (stylesheetInfo.isInline()) {
+                    inlineStyleCount += 1;
+                    stylesheetInfo.setUri(_uac.getBaseURL() + "#inline_style_" + inlineStyleCount);
 
-                if (!ref.isInline()) {
-                    uri = _uac.resolveURI(ref.getUri());
-                    ref.setUri(uri);
+                    Stylesheet sheet = _stylesheetFactory.parse(new StringReader(stylesheetInfo.getContent()), stylesheetInfo);
+                    stylesheetInfo.setStylesheet(sheet);
                 } else {
-                    ref.setUri(_uac.getBaseURL() + "#inline_style_" + (++inlineStyleCount));
-                    Stylesheet sheet = _stylesheetFactory.parse(
-                            new StringReader(ref.getContent()), ref);
-                    ref.setStylesheet(sheet);
-                    ref.setUri(null);
+                    stylesheetInfo.setUri(_uac.resolveURI(stylesheetInfo.getUri()));
                 }
             }
-            infos.addAll(Arrays.asList(refs));
+            infos.addAll(Arrays.asList(stylesheetInfos));
         }
 
         // TODO: here we should also get user stylesheet from userAgent

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -112,7 +112,7 @@ public class StyleReference {
     }
 
     private List<Stylesheet> readAndParseAll(List<StylesheetInfo> infos, String medium) {
-        List<Stylesheet> result = new ArrayList<>(infos.size() * 2);
+        List<Stylesheet> result = new ArrayList<>(infos.size() * 2); // Local aggregation prevents tail recursion, but it's extremely unlikely for this to become an issue.
 
         for (StylesheetInfo info : infos) {
             if (!info.appliesToMedia(medium)) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -236,7 +236,7 @@ public class StyleReference {
                     inlineStyleCount += 1;
                     stylesheetInfo.setUri(_uac.getBaseURL() + "#inline_style_" + inlineStyleCount);
 
-                    Stylesheet sheet = _stylesheetFactory.parse(new StringReader(stylesheetInfo.getContent()), stylesheetInfo);
+                    Stylesheet sheet = _stylesheetFactory.getStylesheet(stylesheetInfo);
                     stylesheetInfo.setStylesheet(sheet);
                 } else {
                     stylesheetInfo.setUri(_uac.resolveURI(stylesheetInfo.getUri()));

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StyleReference.java
@@ -19,25 +19,13 @@
  */
 package com.openhtmltopdf.context;
 
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.logging.Level;
-
-import com.openhtmltopdf.css.newmatch.Matcher;
-import com.openhtmltopdf.css.sheet.FontFaceRule;
-import com.openhtmltopdf.util.LogMessageId;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-
 import com.openhtmltopdf.css.constants.CSSName;
-import com.openhtmltopdf.css.extend.AttributeResolver;
 import com.openhtmltopdf.css.extend.lib.DOMTreeResolver;
 import com.openhtmltopdf.css.newmatch.CascadedStyle;
+import com.openhtmltopdf.css.newmatch.Matcher;
 import com.openhtmltopdf.css.newmatch.PageInfo;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
+import com.openhtmltopdf.css.sheet.FontFaceRule;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.Stylesheet;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
@@ -46,7 +34,16 @@ import com.openhtmltopdf.extend.NamespaceHandler;
 import com.openhtmltopdf.extend.UserAgentCallback;
 import com.openhtmltopdf.extend.UserInterface;
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
 
 
 /**
@@ -147,19 +144,19 @@ public class StyleReference {
      * assigned value as a SAC CSSValue instance. The properties should have
      * been matched to the element when the Context was established for this
      * StyleReference on the Document to which the Element belongs.
-     *
+     * <p>
      * Only used by broken DOM inspector.
      *
      * @param e The DOM Element for which to find properties
      * @return Map of CSS property names to CSSValue instance assigned to it.
      */
     @Deprecated
-	public java.util.Map<String, CSSPrimitiveValue> getCascadedPropertiesMap(Element e) {
+    public java.util.Map<String, CSSPrimitiveValue> getCascadedPropertiesMap(Element e) {
         CascadedStyle cs = _matcher.getCascadedStyle(e, false);
 
-		java.util.Map<String, CSSPrimitiveValue> props = new java.util.LinkedHashMap<>();
+        java.util.Map<String, CSSPrimitiveValue> props = new java.util.LinkedHashMap<>();
 
-		for (PropertyDeclaration pd : cs.getCascadedPropertyDeclarations()) {
+        for (PropertyDeclaration pd : cs.getCascadedPropertyDeclarations()) {
             String propName = pd.getPropertyName();
             CSSName cssName = CSSName.getByPropertyName(propName);
             props.put(propName, cs.propertyByName(cssName).getValue());

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
@@ -21,6 +21,7 @@ package com.openhtmltopdf.context;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -109,15 +110,17 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
      * Returns a sheet by its key
      * null if not able to load
      *
-     *
      * @param info The StylesheetInfo for this sheet
      * @return The stylesheet
      */
     public Stylesheet getStylesheet(StylesheetInfo info) {
+        if (info.isInline()) {
+            return parse(new StringReader(info.getContent()), info);
+        }
+
         XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_REQUESTING_STYLESHEET_AT_URI, info.getUri());
 
         Integer includeCount = _seenStylesheetUris.get(info.getUri());
-
         if (includeCount != null && includeCount >= MAX_STYLESHEET_INCLUDES) {
             // Probably an import loop.
             XRLog.log(Level.SEVERE, LogMessageId.LogMessageId2Param.CSS_PARSE_TOO_MANY_STYLESHEET_IMPORTS, includeCount, info.getUri());

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/StylesheetFactoryImpl.java
@@ -19,13 +19,6 @@
  */
 package com.openhtmltopdf.context;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Level;
-
 import com.openhtmltopdf.css.extend.StylesheetFactory;
 import com.openhtmltopdf.css.parser.CSSParser;
 import com.openhtmltopdf.css.sheet.Ruleset;
@@ -35,6 +28,13 @@ import com.openhtmltopdf.extend.UserAgentCallback;
 import com.openhtmltopdf.resource.CSSResource;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * A Factory class for Cascading Style Sheets. Sheets are parsed using a single
@@ -135,7 +135,7 @@ public class StylesheetFactoryImpl implements StylesheetFactory {
     public void setUserAgentCallback(UserAgentCallback userAgent) {
         _userAgentCallback = userAgent;
     }
-    
+
     public void setSupportCMYKColors(boolean b) {
         _cssParser.setSupportCMYKColors(b);
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -529,14 +529,13 @@ public class CSSParser {
                 skip_whitespace();
                 t = next();
                 if (t == Token.TK_LBRACE) {
-                    LOOP:
                     while (true) {
                         skip_whitespace();
                         t = la();
                         if (t == Token.TK_RBRACE) {
                             next();
                             skip_whitespace();
-                            break LOOP;
+                            break;
                         } else if (t == Token.TK_AT_RULE) {
                             margin(stylesheet, pageRule);
                         } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -158,13 +158,13 @@ public class CSSParser {
                         skip_whitespace();
                         t = next();
                         if (t != Token.TK_SEMICOLON) {
-                            push(t);
+                            save(t);
                             throw new CSSParseException(t, Token.TK_SEMICOLON, getCurrentLine());
                         }
 
                         // Do something
                     } else {
-                        push(t);
+                        save(t);
                         throw new CSSParseException(t, Token.TK_STRING, getCurrentLine());
                     }
                 } catch (CSSParseException e) {
@@ -291,13 +291,13 @@ public class CSSParser {
                         if (t == Token.TK_SEMICOLON) {
                             skip_whitespace();
                         } else {
-                            push(t);
+                            save(t);
                             throw new CSSParseException(
                                     t, Token.TK_SEMICOLON, getCurrentLine());
                         }
                         break;
                     default:
-                        push(t);
+                        save(t);
                         throw new CSSParseException(
                             t, new Token[] { Token.TK_STRING, Token.TK_URI }, getCurrentLine());
                 }
@@ -307,7 +307,7 @@ public class CSSParser {
                 }
                 stylesheet.addImportRule(info);
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(
                         t, Token.TK_IMPORT_SYM, getCurrentLine());
             }
@@ -413,7 +413,7 @@ public class CSSParser {
                         }
                         skip_whitespace();
                     } else {
-                        push(t);
+                        save(t);
                         throw new CSSParseException(t, Token.TK_LBRACE, getCurrentLine());
                     }
                 } else {
@@ -422,7 +422,7 @@ public class CSSParser {
 
                 stylesheet.addContent(mediaRule);
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_MEDIA_SYM, getCurrentLine());
             }
         } catch (CSSParseException e) {
@@ -442,7 +442,7 @@ public class CSSParser {
             result = getTokenValue(t);
             skip_whitespace();
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
         }
         return result;
@@ -483,14 +483,14 @@ public class CSSParser {
                         }
                     }
                 } else {
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t, Token.TK_LBRACE, getCurrentLine());
                 }
 
                 fontFaceRule.addContent(ruleset);
                 stylesheet.addFontFaceRule(fontFaceRule);
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_FONT_FACE_SYM, getCurrentLine());
             }
         } catch (CSSParseException e) {
@@ -542,14 +542,14 @@ public class CSSParser {
                         }
                     }
                 } else {
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t, Token.TK_LBRACE, getCurrentLine());
                 }
 
                 pageRule.addContent(ruleset);
                 stylesheet.addContent(pageRule);
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_PAGE_SYM, getCurrentLine());
             }
         } catch (CSSParseException e) {
@@ -587,7 +587,7 @@ public class CSSParser {
                 declaration_list(ruleset, false, false, false);
                 t = next();
                 if (t != Token.TK_RBRACE) {
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t, Token.TK_RBRACE, getCurrentLine());
                 }
 
@@ -597,7 +597,7 @@ public class CSSParser {
                     pageRule.addMarginBoxProperties(marginBoxName, ruleset.getPropertyDeclarations());
                 }
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_LBRACE, getCurrentLine());
             }
         } catch (CSSParseException e) {
@@ -622,11 +622,11 @@ public class CSSParser {
                     throw new CSSParseException("Pseudo page must be one of first, left, or right", getCurrentLine());
                 }
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
             }
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_COLON, getCurrentLine());
         }
         return result;
@@ -657,7 +657,7 @@ public class CSSParser {
         if (t == Token.TK_PLUS || t == Token.TK_GREATER) {
             skip_whitespace();
         } else if (t != Token.TK_S) {
-            push(t);
+            save(t);
             throw new CSSParseException(
                     t,
                     new Token[] { Token.TK_PLUS, Token.TK_GREATER, Token.TK_S },
@@ -673,7 +673,7 @@ public class CSSParser {
         //System.out.println("unary_operator()");
         Token t = next();
         if (! (t == Token.TK_MINUS || t == Token.TK_PLUS)) {
-            push(t);
+            save(t);
             throw new CSSParseException(
                     t, new Token[] { Token.TK_MINUS, Token.TK_PLUS}, getCurrentLine());
         }
@@ -695,7 +695,7 @@ public class CSSParser {
             result = getTokenValue(t);
             skip_whitespace();
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(
                     t, Token.TK_IDENT, getCurrentLine());
         }
@@ -766,11 +766,11 @@ public class CSSParser {
                 if (t == Token.TK_RBRACE) {
                     skip_whitespace();
                 } else {
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t, Token.TK_RBRACE, getCurrentLine());
                 }
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(
                         t, new Token[] { Token.TK_COMMA, Token.TK_LBRACE }, getCurrentLine());
             }
@@ -1029,11 +1029,11 @@ public class CSSParser {
             if (t == Token.TK_IDENT) {
                 selector.addClassCondition(getTokenValue(t, true));
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
             }
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_PERIOD, getCurrentLine());
         }
     }
@@ -1113,7 +1113,7 @@ public class CSSParser {
                             }
                             skip_whitespace();
                         } else {
-                            push(t);
+                            save(t);
                             throw new CSSParseException(t,
                                     new Token[] { Token.TK_IDENT, Token.TK_STRING },
                                     getCurrentLine());
@@ -1138,7 +1138,7 @@ public class CSSParser {
                         t, new Token[] { Token.TK_IDENT, Token.TK_ASTERISK }, getCurrentLine());
             }
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_LBRACKET, getCurrentLine());
         }
     }
@@ -1183,7 +1183,7 @@ public class CSSParser {
                 skip_whitespace();
                 t = next();
             } else {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
             }
         } else if (f.equals("nth-child")) {
@@ -1196,16 +1196,16 @@ public class CSSParser {
                 selector.addNthChildCondition(number.toString());
             } catch (CSSParseException e) {
                 e.setLine(getCurrentLine());
-                push(t);
+                save(t);
                 throw e;
             }
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(f + " is not a valid function in this context", getCurrentLine());
         }
 
         if (t != Token.TK_RPAREN) {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_RPAREN, getCurrentLine());
         }
     }
@@ -1239,12 +1239,12 @@ public class CSSParser {
                     addPseudoClassOrElementFunction(t, selector);
                     break;
                 default:
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t,
                             new Token[] { Token.TK_IDENT, Token.TK_FUNCTION }, getCurrentLine());
             }
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_COLON, getCurrentLine());
         }
     }
@@ -1334,7 +1334,7 @@ public class CSSParser {
                                 ruleset.getPropertyDeclarations().size() + ruleset.getInvalidPropertyDeclarations().size()));
                     }
                 } else {
-                    push(t);
+                    save(t);
                     throw new CSSParseException(t, Token.TK_COLON, getCurrentLine());
                 }
             } else {
@@ -1355,7 +1355,7 @@ public class CSSParser {
         if (t == Token.TK_IMPORTANT_SYM) {
             skip_whitespace();
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_IMPORTANT_SYM, getCurrentLine());
         }
     }
@@ -1648,7 +1648,7 @@ public class CSSParser {
             List<PropertyValue> params = expr(false);
             t = next();
             if (t != Token.TK_RPAREN) {
-                push(t);
+                save(t);
                 throw new CSSParseException(t, Token.TK_RPAREN, getCurrentLine());
             }
 
@@ -1667,7 +1667,7 @@ public class CSSParser {
 
             skip_whitespace();
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_FUNCTION, getCurrentLine());
         }
 
@@ -1773,7 +1773,7 @@ public class CSSParser {
         if (t == Token.TK_HASH) {
             String s = getTokenValue(t);
             if ((s.length() != 3 && s.length() != 6) || ! isHexString(s)) {
-                push(t);
+                save(t);
                 throw new CSSParseException('#' + s + " is not a valid color definition", getCurrentLine());
             }
             FSRGBColor color = null;
@@ -1791,7 +1791,7 @@ public class CSSParser {
             result = new PropertyValue(color);
             skip_whitespace();
         } else {
-            push(t);
+            save(t);
             throw new CSSParseException(t, Token.TK_HASH, getCurrentLine());
         }
 
@@ -1829,7 +1829,7 @@ public class CSSParser {
         while ( (t = next()) == Token.TK_S) {
             // skip
         }
-        push(t);
+        save(t);
     }
 
     private void skip_whitespace_and_cdocdc() throws IOException {
@@ -1840,7 +1840,7 @@ public class CSSParser {
                 break;
             }
         }
-        push(t);
+        save(t);
     }
 
     private Token next() throws IOException {
@@ -1853,7 +1853,7 @@ public class CSSParser {
         }
     }
 
-    private void push(Token t) {
+    private void save(Token t) {
         if (_saved != null) {
             throw new RuntimeException("saved must be null");
         }
@@ -1862,7 +1862,7 @@ public class CSSParser {
 
     private Token la() throws IOException {
         Token result = next();
-        push(result);
+        save(result);
         return result;
     }
 
@@ -1894,7 +1894,7 @@ public class CSSParser {
                 case Token.RBRACE:
                     if (braces == 0) {
                         if (stopBeforeBlockClose) {
-                            push(t);
+                            save(t);
                             break LOOP;
                         }
                     } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -71,15 +71,14 @@ public class CSSParser {
         _errorHandler = errorHandler;
     }
 
-    public Stylesheet parseStylesheet(String uri, int origin, Reader reader)
-            throws IOException {
+    public Stylesheet parseStylesheet(String uri, int origin, Reader reader) throws IOException {
         _URI = uri;
         reset(reader);
 
-        Stylesheet result = new Stylesheet(uri, origin);
-        stylesheet(result);
+        Stylesheet stylesheet = new Stylesheet(uri, origin);
+        stylesheet(stylesheet);
 
-        return result;
+        return stylesheet;
     }
 
     public Ruleset parseDeclaration(int origin, String text) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -145,7 +145,7 @@ public class CSSParser {
 //      [ [ ruleset | media | page | font_face ] [S|CDO|CDC]* ]*
     private void stylesheet(Stylesheet stylesheet) throws IOException {
         //System.out.println("stylesheet()");
-        Token token = la();
+        Token token = nextWithSave();
         try {
             if (token == Token.TK_CHARSET_SYM) {
                 try {
@@ -174,7 +174,7 @@ public class CSSParser {
             }
             skip_whitespace_and_cdocdc();
             while (true) {
-                token = la();
+                token = nextWithSave();
                 if (token == Token.TK_IMPORT_SYM) {
                     import_rule(stylesheet);
                     skip_whitespace_and_cdocdc();
@@ -183,7 +183,7 @@ public class CSSParser {
                 }
             }
             while (true) {
-                token = la();
+                token = nextWithSave();
                 if (token == Token.TK_NAMESPACE_SYM) {
                     namespace();
                     skip_whitespace_and_cdocdc();
@@ -192,7 +192,7 @@ public class CSSParser {
                 }
             }
             while (true) {
-                token = la();
+                token = nextWithSave();
                 if (token == Token.TK_EOF) {
                     break;
                 }
@@ -267,15 +267,15 @@ public class CSSParser {
                     	info.setUri(resolved);
 
                         skip_whitespace();
-                        t = la();
+                        t = nextWithSave();
                         if (t == Token.TK_IDENT) {
                             info.addMedium(medium());
                             while (true) {
-                                t = la();
+                                t = nextWithSave();
                                 if (t == Token.TK_COMMA) {
                                     next();
                                     skip_whitespace();
-                                    t = la();
+                                    t = nextWithSave();
                                     if (t == Token.TK_IDENT) {
                                         info.addMedium(medium());
                                     } else {
@@ -376,15 +376,15 @@ public class CSSParser {
             if (t == Token.TK_MEDIA_SYM) {
                 MediaRule mediaRule = new MediaRule(stylesheet.getOrigin());
                 skip_whitespace();
-                t = la();
+                t = nextWithSave();
                 if (t == Token.TK_IDENT) {
                     mediaRule.addMedium(medium());
                     while (true) {
-                        t = la();
+                        t = nextWithSave();
                         if (t == Token.TK_COMMA) {
                             next();
                             skip_whitespace();
-                            t = la();
+                            t = nextWithSave();
                             if (t == Token.TK_IDENT) {
                                 mediaRule.addMedium(medium());
                             } else {
@@ -399,7 +399,7 @@ public class CSSParser {
                         skip_whitespace();
                         LOOP:
                         while (true) {
-                            t = la();
+                            t = nextWithSave();
                             if (t == null) {
                                 break;
                             }
@@ -473,7 +473,7 @@ public class CSSParser {
                         if (++i >= maxLoops)
                             throw new CSSParseException(t, Token.TK_RBRACE, getCurrentLine());
                         skip_whitespace();
-                        t = la();
+                        t = nextWithSave();
                         if (t == Token.TK_RBRACE) {
                             next();
                             skip_whitespace();
@@ -510,7 +510,7 @@ public class CSSParser {
             PageRule pageRule = new PageRule(stylesheet.getOrigin());
             if (t == Token.TK_PAGE_SYM) {
                 skip_whitespace();
-                t = la();
+                t = nextWithSave();
                 if (t == Token.TK_IDENT) {
                     String pageName = getTokenValue(t);
                     if (pageName.equals("auto")) {
@@ -518,7 +518,7 @@ public class CSSParser {
                     }
                     next();
                     pageRule.setName(pageName);
-                    t = la();
+                    t = nextWithSave();
                 }
                 if (t == Token.TK_COLON) {
                     pageRule.setPseudoPage(pseudo_page());
@@ -530,7 +530,7 @@ public class CSSParser {
                 if (t == Token.TK_LBRACE) {
                     while (true) {
                         skip_whitespace();
-                        t = la();
+                        t = nextWithSave();
                         if (t == Token.TK_RBRACE) {
                             next();
                             skip_whitespace();
@@ -636,7 +636,7 @@ public class CSSParser {
 //    ;
     private void operator() throws IOException {
         //System.out.println("operator()");
-        Token t = la();
+        Token t = nextWithSave();
         switch (t.getType()) {
             case Token.VIRGULE:
             case Token.COMMA:
@@ -711,7 +711,7 @@ public class CSSParser {
         Token t;
         LOOP:
         while (true) {
-            t = la();
+            t = nextWithSave();
             switch (t.getType()) {
                 case Token.SEMICOLON:
                     next();
@@ -749,7 +749,7 @@ public class CSSParser {
             selector(ruleset);
             Token t;
             while (true) {
-                t = la();
+                t = nextWithSave();
                 if (t == Token.TK_COMMA) {
                     next();
                     skip_whitespace();
@@ -795,13 +795,13 @@ public class CSSParser {
         selectors.add(simple_selector(ruleset));
         LOOP:
         while (true) {
-            Token t = la();
+            Token t = nextWithSave();
             switch (t.getType()) {
                 case Token.PLUS:
                 case Token.GREATER:
                 case Token.S:
                     combinators.add(combinator());
-                    t = la();
+                    t = nextWithSave();
                     switch (t.getType()) {
                         case Token.IDENT:
                         case Token.ASTERISK:
@@ -894,7 +894,7 @@ public class CSSParser {
         //System.out.println("simple_selector()");
         Selector selector = new Selector();
         selector.setParent(ruleset);
-        Token t = la();
+        Token t = nextWithSave();
         switch (t.getType()) {
             case Token.ASTERISK:
             case Token.IDENT:
@@ -904,7 +904,7 @@ public class CSSParser {
                 selector.setName(pair.getName());
 
                 LOOP: while (true) {
-                    t = la();
+                    t = nextWithSave();
                     switch (t.getType()) {
                         case Token.HASH:
                             t = next();
@@ -927,7 +927,7 @@ public class CSSParser {
             default:
                 boolean found = false;
                 LOOP: while (true) {
-                    t = la();
+                    t = nextWithSave();
                     switch (t.getType()) {
                         case Token.HASH:
                             t = next();
@@ -969,13 +969,13 @@ public class CSSParser {
         String prefix = null;
         String name = null;
 
-        Token t = la();
+        Token t = nextWithSave();
         if (t == Token.TK_ASTERISK || t == Token.TK_IDENT) {
             next();
             if (t == Token.TK_IDENT) {
                 name = getTokenValue(t, true);
             }
-            t = la();
+            t = nextWithSave();
         } else if (t == Token.TK_VERTICAL_BAR) {
             prefix = TreeResolver.NO_NAMESPACE;
         } else {
@@ -1070,14 +1070,14 @@ public class CSSParser {
         Token t = next();
         if (t == Token.TK_LBRACKET) {
             skip_whitespace();
-            t = la();
+            t = nextWithSave();
             if (t == Token.TK_IDENT || t == Token.TK_ASTERISK || t == Token.TK_VERTICAL_BAR) {
                 boolean existenceMatch = true;
                 NamespacePair pair = typed_value(true);
                 String attrNamespaceURI = pair.getNamespaceURI();
                 String attrName = pair.getName();
                 skip_whitespace();
-                t = la();
+                t = nextWithSave();
                 switch (t.getType()) {
                     case Token.EQUALS:
                     case Token.INCLUDES:
@@ -1119,7 +1119,7 @@ public class CSSParser {
                                     getCurrentLine());
                         }
                         skip_whitespace();
-                        t = la();
+                        t = nextWithSave();
                         break;
                 }
                 if (existenceMatch) {
@@ -1286,7 +1286,7 @@ public class CSSParser {
     private void declaration(Ruleset ruleset, boolean inFontFace) throws IOException {
         //System.out.println("declaration()");
         try {
-            Token t = la();
+            Token t = nextWithSave();
             if (t == Token.TK_IDENT) {
                 String propertyName = property();
                 CSSName cssName = CSSName.getByPropertyName(propertyName);
@@ -1303,13 +1303,13 @@ public class CSSParser {
                             cssName == CSSName.FS_PDF_FONT_ENCODING);
                     boolean important = false;
 
-                    t = la();
+                    t = nextWithSave();
                     if (t == Token.TK_IMPORTANT_SYM) {
                         prio();
                         important = true;
                     }
 
-                    t = la();
+                    t = nextWithSave();
                     if (! (t == Token.TK_SEMICOLON || t == Token.TK_RBRACE || t == Token.TK_EOF)) {
                         throw new CSSParseException(
                                 t,
@@ -1368,7 +1368,7 @@ public class CSSParser {
         List<PropertyValue> result = new ArrayList<>(10);
         result.add(term(literal));
         LOOP: while (true) {
-            Token t = la();
+            Token t = nextWithSave();
             boolean operator = false;
             Token operatorToken = null;
             switch (t.getType()) {
@@ -1376,7 +1376,7 @@ public class CSSParser {
                 case Token.COMMA:
                     operatorToken = t;
                     operator();
-                    t = la();
+                    t = nextWithSave();
                     operator = true;
                     break;
             }
@@ -1471,10 +1471,10 @@ public class CSSParser {
     private PropertyValue term(boolean literal) throws IOException {
         //System.out.println("term()");
         float sign = 1;
-        Token t = la();
+        Token t = nextWithSave();
         if (t == Token.TK_PLUS || t == Token.TK_MINUS) {
             sign = unary_operator();
-            t = la();
+            t = nextWithSave();
         }
         PropertyValue result = null;
         switch (t.getType()) {
@@ -1860,7 +1860,7 @@ public class CSSParser {
         _saved = t;
     }
 
-    private Token la() throws IOException {
+    private Token nextWithSave() throws IOException {
         Token result = next();
         save(result);
         return result;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -145,27 +145,27 @@ public class CSSParser {
 //      [ [ ruleset | media | page | font_face ] [S|CDO|CDC]* ]*
     private void stylesheet(Stylesheet stylesheet) throws IOException {
         //System.out.println("stylesheet()");
-        Token t = la();
+        Token token = la();
         try {
-            if (t == Token.TK_CHARSET_SYM) {
+            if (token == Token.TK_CHARSET_SYM) {
                 try {
-                    t = next();
+                    token = next();
                     skip_whitespace();
-                    t = next();
-                    if (t == Token.TK_STRING) {
+                    token = next();
+                    if (token == Token.TK_STRING) {
                         /* String charset = getTokenValue(t); */
 
                         skip_whitespace();
-                        t = next();
-                        if (t != Token.TK_SEMICOLON) {
-                            save(t);
-                            throw new CSSParseException(t, Token.TK_SEMICOLON, getCurrentLine());
+                        token = next();
+                        if (token != Token.TK_SEMICOLON) {
+                            save(token);
+                            throw new CSSParseException(token, Token.TK_SEMICOLON, getCurrentLine());
                         }
 
                         // Do something
                     } else {
-                        save(t);
-                        throw new CSSParseException(t, Token.TK_STRING, getCurrentLine());
+                        save(token);
+                        throw new CSSParseException(token, Token.TK_STRING, getCurrentLine());
                     }
                 } catch (CSSParseException e) {
                     error(e, "@charset rule", true);
@@ -174,8 +174,8 @@ public class CSSParser {
             }
             skip_whitespace_and_cdocdc();
             while (true) {
-                t = la();
-                if (t == Token.TK_IMPORT_SYM) {
+                token = la();
+                if (token == Token.TK_IMPORT_SYM) {
                     import_rule(stylesheet);
                     skip_whitespace_and_cdocdc();
                 } else {
@@ -183,8 +183,8 @@ public class CSSParser {
                 }
             }
             while (true) {
-                t = la();
-                if (t == Token.TK_NAMESPACE_SYM) {
+                token = la();
+                if (token == Token.TK_NAMESPACE_SYM) {
                     namespace();
                     skip_whitespace_and_cdocdc();
                 } else {
@@ -192,11 +192,11 @@ public class CSSParser {
                 }
             }
             while (true) {
-                t = la();
-                if (t == Token.TK_EOF) {
+                token = la();
+                if (token == Token.TK_EOF) {
                     break;
                 }
-                switch (t.getType()) {
+                switch (token.getType()) {
                     case Token.PAGE_SYM:
                         page(stylesheet);
                         break;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -147,6 +147,8 @@ public class CSSParser {
         //System.out.println("stylesheet()");
         Token token = nextWithSave();
         try {
+            /* March 2024: https://archive.is/MRe2d
+            "The @charset rule must be the first element in the style sheet and not be preceded by any character" */
             if (token == Token.TK_CHARSET_SYM) {
                 try {
                     token = next();
@@ -173,8 +175,13 @@ public class CSSParser {
                 }
             }
             skip_whitespace_and_cdocdc();
+
+            /* March 2024: https://archive.ph/tMcxr
+            "An @import rule must be defined at the top of the stylesheet, before any other at-rule (except @charset and @layer) and style declarations, or it will be ignored." */
             while (true) {
                 token = nextWithSave();
+                /* todo: zach: Add awareness of @layer at-rule https://archive.is/Jy0Jp
+                @layer may appear before @import. If it does, the parser will ignore all @import rules. */
                 if (token == Token.TK_IMPORT_SYM) {
                     import_rule(stylesheet);
                     skip_whitespace_and_cdocdc();
@@ -182,8 +189,12 @@ public class CSSParser {
                     break;
                 }
             }
+
+            /* March 2024: https://archive.is/Yreun
+            "Any @namespace rules must follow all @charset and @import rules, and precede all other at-rules and style declarations in a style sheet." */
             while (true) {
                 token = nextWithSave();
+                // todo: zach: ignore @layer here too
                 if (token == Token.TK_NAMESPACE_SYM) {
                     namespace();
                     skip_whitespace_and_cdocdc();
@@ -191,6 +202,7 @@ public class CSSParser {
                     break;
                 }
             }
+
             while (true) {
                 token = nextWithSave();
                 if (token == Token.TK_EOF) {
@@ -1879,7 +1891,7 @@ public class CSSParser {
                     braces++;
                     break;
                 case Token.RBRACE:
-                    if (braces == 0) {
+                    if (braces == 0) { // todo: zach: is this condition satisfiable?
                         if (stopBeforeBlockClose) {
                             save(t);
                             break LOOP;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -1305,7 +1305,8 @@ public class CSSParser {
 
                     t = nextWithSave();
                     if (t == Token.TK_IMPORTANT_SYM) {
-                        prio();
+                        next();
+                        skip_whitespace();
                         important = true;
                     }
 
@@ -1343,20 +1344,6 @@ public class CSSParser {
         } catch (CSSParseException e) {
             error(e, "declaration", true);
             recover(false, true);
-        }
-    }
-
-//  prio
-//    : IMPORTANT_SYM S*
-//    ;
-    private void prio() throws IOException {
-        //System.out.println("prio()");
-        Token t = next();
-        if (t == Token.TK_IMPORTANT_SYM) {
-            skip_whitespace();
-        } else {
-            save(t);
-            throw new CSSParseException(t, Token.TK_IMPORTANT_SYM, getCurrentLine());
         }
     }
 
@@ -1977,11 +1964,8 @@ public class CSSParser {
             case Token.AT_RULE:
             case Token.IDENT:
             case Token.FUNCTION:
-                start = 0;
+                start = t.getType() == Token.AT_RULE ? 1 : 0;
                 count = _lexer.yylength();
-                if (t.getType() == Token.AT_RULE) {
-                    start++;
-                }
                 String result = processEscapes(_lexer.yytext().toCharArray(), start, count);
                 if (! literal) {
                     result = result.toLowerCase();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -109,8 +109,8 @@ public class CSSParser {
             reset(new StringReader(expr));
             List<PropertyValue> values = expr(
                     cssName == CSSName.FONT_FAMILY ||
-                    cssName == CSSName.FONT_SHORTHAND ||
-                    cssName == CSSName.FS_PDF_FONT_ENCODING);
+                            cssName == CSSName.FONT_SHORTHAND ||
+                            cssName == CSSName.FS_PDF_FONT_ENCODING);
 
             PropertyBuilder builder = CSSName.getPropertyBuilder(cssName);
             List<PropertyDeclaration> props;
@@ -128,7 +128,7 @@ public class CSSParser {
 
             PropertyDeclaration decl = props.get(0);
 
-            return (PropertyValue)decl.getValue();
+            return (PropertyValue) decl.getValue();
         } catch (IOException e) {
             // "Shouldn't" happen
             throw new RuntimeException(e.getMessage(), e);
@@ -138,7 +138,7 @@ public class CSSParser {
         }
     }
 
-//    stylesheet
+    //    stylesheet
 //    : [ CHARSET_SYM S* STRING S* ';' ]?
 //      [S|CDO|CDC]* [ import [S|CDO|CDC]* ]*
 //      [ namespace [S|CDO|CDC]* ]*
@@ -243,13 +243,13 @@ public class CSSParser {
             }
         } catch (CSSParseException e) {
             // "shouldn't" happen
-            if (! e.isCallerNotified()) {
+            if (!e.isCallerNotified()) {
                 error(e, "stylesheet", false);
             }
         }
     }
 
-//  import
+    //  import
 //  : IMPORT_SYM S*
 //    [STRING|URI] S* [ medium [ COMMA S* medium]* ]? ';' S*
 //  ;
@@ -267,16 +267,16 @@ public class CSSParser {
                 switch (t.getType()) {
                     case Token.STRING:
                     case Token.URI:
-                    	String uri = getTokenValue(t);
-                    	String baseUri = stylesheet.getURI();
-                    	
-                    	String resolved = ThreadCtx.get().sharedContext().getUserAgentCallback().resolveUri(baseUri, uri);
-                    	
-                    	if (resolved == null) {
-                    	    XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_URI_RESOLVER_REJECTED_RESOLVING_CSS_IMPORT_AT_URI, uri);
-                    	}
-                    	
-                    	info.setUri(resolved);
+                        String uri = getTokenValue(t);
+                        String baseUri = stylesheet.getURI();
+
+                        String resolved = ThreadCtx.get().sharedContext().getUserAgentCallback().resolveUri(baseUri, uri);
+
+                        if (resolved == null) {
+                            XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_URI_RESOLVER_REJECTED_RESOLVING_CSS_IMPORT_AT_URI, uri);
+                        }
+
+                        info.setUri(resolved);
 
                         skip_whitespace();
                         t = nextWithSave();
@@ -311,7 +311,7 @@ public class CSSParser {
                     default:
                         save(t);
                         throw new CSSParseException(
-                            t, new Token[] { Token.TK_STRING, Token.TK_URI }, getCurrentLine());
+                                t, new Token[]{Token.TK_STRING, Token.TK_URI}, getCurrentLine());
                 }
 
                 if (info.getMedia().isEmpty()) {
@@ -329,7 +329,7 @@ public class CSSParser {
         }
     }
 
-//  namespace
+    //  namespace
 //  : NAMESPACE_SYM S* [namespace_prefix S*]? [STRING|URI] S* ';' S*
 //  ;
 //  namespace_prefix
@@ -355,7 +355,7 @@ public class CSSParser {
                     url = getTokenValue(t);
                 } else {
                     throw new CSSParseException(
-                            t, new Token[] { Token.TK_STRING, Token.TK_URI }, getCurrentLine());
+                            t, new Token[]{Token.TK_STRING, Token.TK_URI}, getCurrentLine());
                 }
 
                 skip_whitespace();
@@ -378,7 +378,7 @@ public class CSSParser {
         }
     }
 
-//  media
+    //  media
 //  : MEDIA_SYM S* medium [ COMMA S* medium ]* LBRACE S* ruleset* '}' S*
 //  ;
     private void media(Stylesheet stylesheet) throws IOException {
@@ -443,7 +443,7 @@ public class CSSParser {
         }
     }
 
-//  medium
+    //  medium
 //  : IDENT S*
 //  ;
     private String medium() throws IOException {
@@ -460,7 +460,7 @@ public class CSSParser {
         return result;
     }
 
-//  font_face
+    //  font_face
 //    : FONT_FACE_SYM S*
 //      '{' S* declaration [ ';' S* declaration ]* '}' S*
 //    ;
@@ -511,7 +511,7 @@ public class CSSParser {
         }
     }
 
-//  page :
+    //  page :
 //    PAGE_SYM S* IDENT? pseudo_page? S* 
 //    '{' S* [ declaration | margin ]? [ ';' S* [ declaration | margin ]? ]* '}' S*
 //
@@ -570,7 +570,7 @@ public class CSSParser {
         }
     }
 
-//  margin :
+    //  margin :
 //    margin_sym S* '{' declaration [ ';' S* declaration? ]* '}' S*
 //    ;
     private void margin(Stylesheet stylesheet, PageRule pageRule) throws IOException {
@@ -619,7 +619,7 @@ public class CSSParser {
     }
 
 
-//  pseudo_page
+    //  pseudo_page
 //    : ':' IDENT
 //    ;
     private String pseudo_page() throws IOException {
@@ -630,7 +630,7 @@ public class CSSParser {
             t = next();
             if (t == Token.TK_IDENT) {
                 result = getTokenValue(t);
-                if (! (result.equals("first") || result.equals("left") || result.equals("right"))) {
+                if (!(result.equals("first") || result.equals("left") || result.equals("right"))) {
                     throw new CSSParseException("Pseudo page must be one of first, left, or right", getCurrentLine());
                 }
             } else {
@@ -643,7 +643,8 @@ public class CSSParser {
         }
         return result;
     }
-//  operator
+
+    //  operator
 //    : '/' S* | COMMA S* | /* empty */
 //    ;
     private void operator() throws IOException {
@@ -658,7 +659,7 @@ public class CSSParser {
         }
     }
 
-//  combinator
+    //  combinator
 //    : PLUS S*
 //    | GREATER S*
 //    | S
@@ -672,22 +673,22 @@ public class CSSParser {
             save(t);
             throw new CSSParseException(
                     t,
-                    new Token[] { Token.TK_PLUS, Token.TK_GREATER, Token.TK_S },
+                    new Token[]{Token.TK_PLUS, Token.TK_GREATER, Token.TK_S},
                     getCurrentLine());
         }
         return t;
     }
 
-//  unary_operator
+    //  unary_operator
 //    : '-' | PLUS
 //    ;
     private int unary_operator() throws IOException {
         //System.out.println("unary_operator()");
         Token t = next();
-        if (! (t == Token.TK_MINUS || t == Token.TK_PLUS)) {
+        if (!(t == Token.TK_MINUS || t == Token.TK_PLUS)) {
             save(t);
             throw new CSSParseException(
-                    t, new Token[] { Token.TK_MINUS, Token.TK_PLUS}, getCurrentLine());
+                    t, new Token[]{Token.TK_MINUS, Token.TK_PLUS}, getCurrentLine());
         }
         if (t == Token.TK_MINUS) {
             return -1;
@@ -696,7 +697,7 @@ public class CSSParser {
         }
     }
 
-//  property
+    //  property
 //    : IDENT S*
 //    ;
     private String property() throws IOException {
@@ -715,7 +716,7 @@ public class CSSParser {
         return result;
     }
 
-//  declaration_list
+    //  declaration_list
 //    : [ declaration ';' S* ]*
     private void declaration_list(
             Ruleset ruleset, boolean expectEOF, boolean expectAtRule, boolean inFontFace) throws IOException {
@@ -749,7 +750,7 @@ public class CSSParser {
         }
     }
 
-//  ruleset
+    //  ruleset
 //    : selector [ COMMA S* selector ]*
 //      LBRACE S* [ declaration ';' S* ]* '}' S*
 //    ;
@@ -784,11 +785,11 @@ public class CSSParser {
             } else {
                 save(t);
                 throw new CSSParseException(
-                        t, new Token[] { Token.TK_COMMA, Token.TK_LBRACE }, getCurrentLine());
+                        t, new Token[]{Token.TK_COMMA, Token.TK_LBRACE}, getCurrentLine());
             }
 
             if (!ruleset.getPropertyDeclarations().isEmpty() ||
-                !ruleset.getInvalidPropertyDeclarations().isEmpty()) {
+                    !ruleset.getInvalidPropertyDeclarations().isEmpty()) {
                 container.addContent(ruleset);
             }
         } catch (CSSParseException e) {
@@ -797,7 +798,7 @@ public class CSSParser {
         }
     }
 
-//  selector
+    //  selector
 //    : simple_selector [ combinator simple_selector ]*
 //    ;
     private void selector(Ruleset ruleset) throws IOException {
@@ -824,9 +825,9 @@ public class CSSParser {
                             selectors.add(simple_selector(ruleset));
                             break;
                         default:
-                            throw new CSSParseException(t, new Token[] { Token.TK_IDENT,
+                            throw new CSSParseException(t, new Token[]{Token.TK_IDENT,
                                     Token.TK_ASTERISK, Token.TK_HASH, Token.TK_PERIOD,
-                                    Token.TK_LBRACKET, Token.TK_COLON }, getCurrentLine());
+                                    Token.TK_LBRACKET, Token.TK_COLON}, getCurrentLine());
                     }
                     break;
                 default:
@@ -852,7 +853,7 @@ public class CSSParser {
             if (first.getPseudoElement() != null) {
                 throw new CSSParseException(
                         "A simple selector with a pseudo element cannot be " +
-                        "combined with another simple selector", getCurrentLine());
+                                "combined with another simple selector", getCurrentLine());
             }
 
             boolean sibling = false;
@@ -871,7 +872,7 @@ public class CSSParser {
             second.setSpecificityC(second.getSpecificityC() + first.getSpecificityC());
             second.setSpecificityD(second.getSpecificityD() + first.getSpecificityD());
 
-            if (! sibling) {
+            if (!sibling) {
                 if (result == null) {
                     result = first;
                 }
@@ -883,7 +884,7 @@ public class CSSParser {
                     result = second;
                 }
                 if (i > 0) {
-                    for (int j = i-1; j >= 0; j--) {
+                    for (int j = i - 1; j >= 0; j--) {
                         Selector selector = selectors.get(j);
                         if (selector.getChainedSelector() == first) {
                             selector.setChainedSelector(second);
@@ -898,7 +899,7 @@ public class CSSParser {
         return result;
     }
 
-//  simple_selector
+    //  simple_selector
 //    : typed_value [ HASH | class | attrib | pseudo ]*
 //    | [ HASH | class | attrib | pseudo ]+
 //    ;
@@ -915,7 +916,8 @@ public class CSSParser {
                 selector.setNamespaceURI(pair.getNamespaceURI());
                 selector.setName(pair.getName());
 
-                LOOP: while (true) {
+                LOOP:
+                while (true) {
                     t = nextWithSave();
                     switch (t.getType()) {
                         case Token.HASH:
@@ -938,7 +940,8 @@ public class CSSParser {
                 break;
             default:
                 boolean found = false;
-                LOOP: while (true) {
+                LOOP:
+                while (true) {
                     t = nextWithSave();
                     switch (t.getType()) {
                         case Token.HASH:
@@ -960,8 +963,8 @@ public class CSSParser {
                             break;
                         default:
                             if (!found) {
-                                throw new CSSParseException(t, new Token[] { Token.TK_HASH,
-                                        Token.TK_PERIOD, Token.TK_LBRACKET, Token.TK_COLON },
+                                throw new CSSParseException(t, new Token[]{Token.TK_HASH,
+                                        Token.TK_PERIOD, Token.TK_LBRACKET, Token.TK_COLON},
                                         getCurrentLine());
                             }
                             break LOOP;
@@ -971,7 +974,7 @@ public class CSSParser {
         return selector;
     }
 
-//    type_selector
+    //    type_selector
 //    : [ namespace_prefix ]? element_name | IDENT
 //    ;
 //    namespace_prefix
@@ -992,7 +995,7 @@ public class CSSParser {
             prefix = TreeResolver.NO_NAMESPACE;
         } else {
             throw new CSSParseException(
-                    t, new Token[] { Token.TK_ASTERISK, Token.TK_IDENT, Token.TK_VERTICAL_BAR },
+                    t, new Token[]{Token.TK_ASTERISK, Token.TK_IDENT, Token.TK_VERTICAL_BAR},
                     getCurrentLine());
         }
 
@@ -1008,7 +1011,7 @@ public class CSSParser {
                 }
             } else {
                 throw new CSSParseException(
-                        t, new Token[] { Token.TK_ASTERISK, Token.TK_IDENT }, getCurrentLine());
+                        t, new Token[]{Token.TK_ASTERISK, Token.TK_IDENT}, getCurrentLine());
             }
         }
 
@@ -1019,7 +1022,7 @@ public class CSSParser {
                 throw new CSSParseException("There is no namespace with prefix " + prefix + " defined",
                         getCurrentLine());
             }
-        } else if (prefix == null && ! matchAttribute) {
+        } else if (prefix == null && !matchAttribute) {
             namespaceURI = _namespaces.get(null);
         }
 
@@ -1030,7 +1033,7 @@ public class CSSParser {
         return new NamespacePair(namespaceURI, name);
     }
 
-//  class
+    //  class
 //    : '.' IDENT
 //    ;
     private void class_selector(Selector selector) throws IOException {
@@ -1067,7 +1070,7 @@ public class CSSParser {
     }
     */
 
-//    attrib
+    //    attrib
 //    : '[' S* [ namespace_prefix ]? IDENT S*
 //          [ [ PREFIXMATCH |
 //              SUFFIXMATCH |
@@ -1127,7 +1130,7 @@ public class CSSParser {
                         } else {
                             save(t);
                             throw new CSSParseException(t,
-                                    new Token[] { Token.TK_IDENT, Token.TK_STRING },
+                                    new Token[]{Token.TK_IDENT, Token.TK_STRING},
                                     getCurrentLine());
                         }
                         skip_whitespace();
@@ -1140,14 +1143,14 @@ public class CSSParser {
                 if (t == Token.TK_RBRACKET) {
                     next();
                 } else {
-                    throw new CSSParseException(t, new Token[] { Token.TK_EQUALS,
+                    throw new CSSParseException(t, new Token[]{Token.TK_EQUALS,
                             Token.TK_INCLUDES, Token.TK_DASHMATCH, Token.TK_PREFIXMATCH,
-                            Token.TK_SUFFIXMATCH, Token.TK_SUBSTRINGMATCH, Token.TK_RBRACKET },
+                            Token.TK_SUFFIXMATCH, Token.TK_SUBSTRINGMATCH, Token.TK_RBRACKET},
                             getCurrentLine());
                 }
             } else {
                 throw new CSSParseException(
-                        t, new Token[] { Token.TK_IDENT, Token.TK_ASTERISK }, getCurrentLine());
+                        t, new Token[]{Token.TK_IDENT, Token.TK_ASTERISK}, getCurrentLine());
             }
         } else {
             save(t);
@@ -1175,7 +1178,7 @@ public class CSSParser {
             selector.addOddChildCondition();
         } else if (value.equals("last-child")) {
             selector.addLastChildCondition();
-        } else if (CSS21_PSEUDO_ELEMENTS.contains(value)){
+        } else if (CSS21_PSEUDO_ELEMENTS.contains(value)) {
             selector.setPseudoElement(value);
         } else {
             throw new CSSParseException(value + " is not a recognized pseudo-class", getCurrentLine());
@@ -1184,7 +1187,7 @@ public class CSSParser {
 
     private void addPseudoClassOrElementFunction(Token t, Selector selector) throws IOException {
         String f = getTokenValue(t);
-        f = f.substring(0, f.length()-1);
+        f = f.substring(0, f.length() - 1);
 
         if (f.equals("lang")) {
             skip_whitespace();
@@ -1231,7 +1234,7 @@ public class CSSParser {
         }
     }
 
-//  pseudo
+    //  pseudo
 //    : ':' ':'? [ IDENT | FUNCTION S* IDENT? S* ')' ]
 //    ;
     private void pseudo(Selector selector) throws IOException {
@@ -1253,7 +1256,7 @@ public class CSSParser {
                 default:
                     save(t);
                     throw new CSSParseException(t,
-                            new Token[] { Token.TK_IDENT, Token.TK_FUNCTION }, getCurrentLine());
+                            new Token[]{Token.TK_IDENT, Token.TK_FUNCTION}, getCurrentLine());
             }
         } else {
             save(t);
@@ -1265,18 +1268,18 @@ public class CSSParser {
         if (cssName == null) {
             if (!SVGProperty.properties().contains(propertyName)) {
                 _errorHandler.error(
-                    _URI,
-                    propertyName + " is an unrecognized CSS property at line "
-                        + getCurrentLine() + ". Ignoring declaration.");
+                        _URI,
+                        propertyName + " is an unrecognized CSS property at line "
+                                + getCurrentLine() + ". Ignoring declaration.");
             }
             return false;
         }
 
-        if (! CSSName.isImplemented(cssName)) {
+        if (!CSSName.isImplemented(cssName)) {
             _errorHandler.error(
                     _URI,
                     propertyName + " is not implemented at line "
-                        + getCurrentLine() + ". Ignoring declaration.");
+                            + getCurrentLine() + ". Ignoring declaration.");
             return false;
         }
 
@@ -1285,14 +1288,14 @@ public class CSSParser {
             _errorHandler.error(
                     _URI,
                     "(bug) No property builder defined for " + propertyName
-                        + " at line " + getCurrentLine() + ". Ignoring declaration.");
+                            + " at line " + getCurrentLine() + ". Ignoring declaration.");
             return false;
         }
 
         return true;
     }
 
-//  declaration
+    //  declaration
 //    : property ':' S* expr prio?
 //    ;
     private void declaration(Ruleset ruleset, boolean inFontFace) throws IOException {
@@ -1311,8 +1314,8 @@ public class CSSParser {
 
                     List<PropertyValue> values = expr(
                             cssName == CSSName.FONT_FAMILY ||
-                            cssName == CSSName.FONT_SHORTHAND ||
-                            cssName == CSSName.FS_PDF_FONT_ENCODING);
+                                    cssName == CSSName.FONT_SHORTHAND ||
+                                    cssName == CSSName.FS_PDF_FONT_ENCODING);
                     boolean important = false;
 
                     t = nextWithSave();
@@ -1323,10 +1326,10 @@ public class CSSParser {
                     }
 
                     t = nextWithSave();
-                    if (! (t == Token.TK_SEMICOLON || t == Token.TK_RBRACE || t == Token.TK_EOF)) {
+                    if (!(t == Token.TK_SEMICOLON || t == Token.TK_RBRACE || t == Token.TK_EOF)) {
                         throw new CSSParseException(
                                 t,
-                                new Token[] { Token.TK_SEMICOLON, Token.TK_RBRACE },
+                                new Token[]{Token.TK_SEMICOLON, Token.TK_RBRACE},
                                 getCurrentLine());
                     }
 
@@ -1342,9 +1345,9 @@ public class CSSParser {
                     } else {
                         // We need to keep invalid properties in case they are used by SVG, etc.
                         ruleset.addInvalidProperty(
-                           new InvalidPropertyDeclaration(
-                                propertyName, values, ruleset.getOrigin(), important,
-                                ruleset.getPropertyDeclarations().size() + ruleset.getInvalidPropertyDeclarations().size()));
+                                new InvalidPropertyDeclaration(
+                                        propertyName, values, ruleset.getOrigin(), important,
+                                        ruleset.getPropertyDeclarations().size() + ruleset.getInvalidPropertyDeclarations().size()));
                     }
                 } else {
                     save(t);
@@ -1359,14 +1362,15 @@ public class CSSParser {
         }
     }
 
-//  expr
+    //  expr
 //    : term [ operator term ]*
 //    ;
     private List<PropertyValue> expr(boolean literal) throws IOException {
         //System.out.println("expr()");
         List<PropertyValue> result = new ArrayList<>(10);
         result.add(term(literal));
-        LOOP: while (true) {
+        LOOP:
+        while (true) {
             Token t = nextWithSave();
             boolean operator = false;
             Token operatorToken = null;
@@ -1409,12 +1413,12 @@ public class CSSParser {
                     break;
                 default:
                     if (operator) {
-                        throw new CSSParseException(t, new Token[] {
+                        throw new CSSParseException(t, new Token[]{
                                 Token.TK_NUMBER, Token.TK_PLUS, Token.TK_MINUS,
                                 Token.TK_PERCENTAGE, Token.TK_PX, Token.TK_EMS, Token.TK_EXS,
                                 Token.TK_PC, Token.TK_MM, Token.TK_CM, Token.TK_IN, Token.TK_PT,
                                 Token.TK_ANGLE, Token.TK_TIME, Token.TK_FREQ, Token.TK_STRING,
-                                Token.TK_IDENT, Token.TK_URI, Token.TK_HASH, Token.TK_FUNCTION },
+                                Token.TK_IDENT, Token.TK_URI, Token.TK_HASH, Token.TK_FUNCTION},
                                 getCurrentLine());
                     } else {
                         break LOOP;
@@ -1461,7 +1465,7 @@ public class CSSParser {
         return sign == -1.0f ? "-" : "";
     }
 
-//  term
+    //  term
 //    : unary_operator?
 //      [ NUMBER S* | PERCENTAGE S* | LENGTH S* | EMS S* | EXS S* | ANGLE S* |
 //        TIME S* | FREQ S* ]
@@ -1484,9 +1488,9 @@ public class CSSParser {
 
                 if ("rem".equals(unitType)) {
                     result = new PropertyValue(
-                          CSSPrimitiveValue.CSS_REMS,
-                          sign*Float.parseFloat(extractNumber(t)),
-                          sign(sign) + getTokenValue(t));
+                            CSSPrimitiveValue.CSS_REMS,
+                            sign * Float.parseFloat(extractNumber(t)),
+                            sign(sign) + getTokenValue(t));
                     next();
                     skip_whitespace();
                 } else {
@@ -1496,25 +1500,25 @@ public class CSSParser {
             case Token.NUMBER:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_NUMBER,
-                        sign*Float.parseFloat(getTokenValue(t)),
+                        sign * Float.parseFloat(getTokenValue(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
                 break;
             case Token.ANGLE:
-            	String unit = extractUnit(t);
-            	short type = CSSPrimitiveValue.CSS_UNKNOWN;
+                String unit = extractUnit(t);
+                short type = CSSPrimitiveValue.CSS_UNKNOWN;
 
-            	if ("deg".equals(unit))
-            		type = CSSPrimitiveValue.CSS_DEG;
-            	else if ("rad".equals(unit))
-            		type = CSSPrimitiveValue.CSS_RAD;
-            	else if ("grad".equals(unit))
-            		type = CSSPrimitiveValue.CSS_GRAD;
-            	
+                if ("deg".equals(unit))
+                    type = CSSPrimitiveValue.CSS_DEG;
+                else if ("rad".equals(unit))
+                    type = CSSPrimitiveValue.CSS_RAD;
+                else if ("grad".equals(unit))
+                    type = CSSPrimitiveValue.CSS_GRAD;
+
                 result = new PropertyValue(
                         type,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1522,7 +1526,7 @@ public class CSSParser {
             case Token.PERCENTAGE:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_PERCENTAGE,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1530,7 +1534,7 @@ public class CSSParser {
             case Token.EMS:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_EMS,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1538,7 +1542,7 @@ public class CSSParser {
             case Token.EXS:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_EXS,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1546,7 +1550,7 @@ public class CSSParser {
             case Token.PX:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_PX,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1554,7 +1558,7 @@ public class CSSParser {
             case Token.CM:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_CM,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1562,7 +1566,7 @@ public class CSSParser {
             case Token.MM:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_MM,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1570,7 +1574,7 @@ public class CSSParser {
             case Token.IN:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_IN,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1578,7 +1582,7 @@ public class CSSParser {
             case Token.PT:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_PT,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1586,7 +1590,7 @@ public class CSSParser {
             case Token.PC:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_PC,
-                        sign*Float.parseFloat(extractNumber(t)),
+                        sign * Float.parseFloat(extractNumber(t)),
                         sign(sign) + getTokenValue(t));
                 next();
                 skip_whitespace();
@@ -1624,17 +1628,17 @@ public class CSSParser {
                 result = function();
                 break;
             default:
-                throw new CSSParseException(t, new Token[] { Token.TK_NUMBER,
+                throw new CSSParseException(t, new Token[]{Token.TK_NUMBER,
                         Token.TK_PERCENTAGE, Token.TK_PX, Token.TK_EMS, Token.TK_EXS,
                         Token.TK_PC, Token.TK_MM, Token.TK_CM, Token.TK_IN, Token.TK_PT,
                         Token.TK_ANGLE, Token.TK_TIME, Token.TK_FREQ, Token.TK_STRING,
-                        Token.TK_IDENT, Token.TK_URI, Token.TK_HASH, Token.TK_FUNCTION },
+                        Token.TK_IDENT, Token.TK_URI, Token.TK_HASH, Token.TK_FUNCTION},
                         getCurrentLine());
         }
         return result;
     }
 
-//  function
+    //  function
 //    : FUNCTION S* expr ')' S*
 //    ;
     private PropertyValue function() throws IOException {
@@ -1654,14 +1658,14 @@ public class CSSParser {
             if (f.equals("rgb(")) {
                 result = new PropertyValue(createRGBColorFromFunction(params));
             } else if (f.equals("cmyk(")) {
-                if (! isSupportCMYKColors()) {
+                if (!isSupportCMYKColors()) {
                     throw new CSSParseException(
                             "The current output device does not support CMYK colors", getCurrentLine());
                 }
                 //in accordance to http://www.w3.org/TR/css3-gcpm/#cmyk-colors
                 result = new PropertyValue(createCMYKColorFromFunction(params));
             } else {
-                result = new PropertyValue(new FSFunction(f.substring(0, f.length()-1), params));
+                result = new PropertyValue(new FSFunction(f.substring(0, f.length() - 1), params));
             }
 
             skip_whitespace();
@@ -1683,7 +1687,7 @@ public class CSSParser {
         float[] colorComponents = new float[4];
 
         for (int i = 0; i < params.size(); i++) {
-            colorComponents[i] = parseCMYKColorComponent(params.get(i), (i+1)); //Warning on the truncation?
+            colorComponents[i] = parseCMYKColorComponent(params.get(i), (i + 1)); //Warning on the truncation?
         }
 
         return new FSCMYKColor(colorComponents[0], colorComponents[1], colorComponents[2], colorComponents[3]);
@@ -1700,7 +1704,7 @@ public class CSSParser {
         } else {
             throw new CSSParseException(
                     "Parameter " + paramNo + " to the cmyk() function is " +
-                    "not a number or a percentage", getCurrentLine());
+                            "not a number or a percentage", getCurrentLine());
         }
 
         if (result < 0.0f || result > 1.0f) {
@@ -1727,13 +1731,13 @@ public class CSSParser {
             if (type != CSSPrimitiveValue.CSS_PERCENTAGE &&
                     type != CSSPrimitiveValue.CSS_NUMBER) {
                 throw new CSSParseException(
-                        "Parameter " + (i+1) + " to the rgb() function is " +
-                        "not a number or percentage", getCurrentLine());
+                        "Parameter " + (i + 1) + " to the rgb() function is " +
+                                "not a number or percentage", getCurrentLine());
             }
 
             float f = value.getFloatValue();
             if (type == CSSPrimitiveValue.CSS_PERCENTAGE) {
-                f = f/100 * 255;
+                f = f / 100 * 255;
             }
             if (f < 0) {
                 f = 0;
@@ -1743,13 +1747,13 @@ public class CSSParser {
 
             switch (i) {
                 case 0:
-                    red = (int)f;
+                    red = (int) f;
                     break;
                 case 1:
-                    green = (int)f;
+                    green = (int) f;
                     break;
                 case 2:
-                    blue = (int)f;
+                    blue = (int) f;
                     break;
             }
         }
@@ -1757,7 +1761,7 @@ public class CSSParser {
         return new FSRGBColor(red, green, blue);
     }
 
-//  /*
+    //  /*
 //  * There is a constraint on the color that it must
 //  * have either 3 or 6 hex-digits (i.e., [0-9a-fA-F])
 //  * after the "#"; e.g., "#000" is OK, but "#abcd" is not.
@@ -1771,16 +1775,16 @@ public class CSSParser {
         Token t = next();
         if (t == Token.TK_HASH) {
             String s = getTokenValue(t);
-            if ((s.length() != 3 && s.length() != 6) || ! isHexString(s)) {
+            if ((s.length() != 3 && s.length() != 6) || !isHexString(s)) {
                 save(t);
                 throw new CSSParseException('#' + s + " is not a valid color definition", getCurrentLine());
             }
             FSRGBColor color = null;
             if (s.length() == 3) {
                 color = new FSRGBColor(
-                            convertToInteger(s.charAt(0), s.charAt(0)),
-                            convertToInteger(s.charAt(1), s.charAt(1)),
-                            convertToInteger(s.charAt(2), s.charAt(2)));
+                        convertToInteger(s.charAt(0), s.charAt(0)),
+                        convertToInteger(s.charAt(1), s.charAt(1)),
+                        convertToInteger(s.charAt(2), s.charAt(2)));
             } else { /* s.length == 6 */
                 color = new FSRGBColor(
                         convertToInteger(s.charAt(0), s.charAt(1)),
@@ -1799,7 +1803,7 @@ public class CSSParser {
 
     private boolean isHexString(String s) {
         for (int i = 0; i < s.length(); i++) {
-            if (! isHexChar(s.charAt(i))) {
+            if (!isHexChar(s.charAt(i))) {
                 return false;
             }
         }
@@ -1825,7 +1829,7 @@ public class CSSParser {
 
     private void skip_whitespace() throws IOException {
         Token t;
-        while ( (t = next()) == Token.TK_S) {
+        while ((t = next()) == Token.TK_S) {
             // skip
         }
         save(t);
@@ -1835,7 +1839,7 @@ public class CSSParser {
         Token t;
         while (true) {
             t = next();
-            if (! (t == Token.TK_S || t == Token.TK_CDO || t == Token.TK_CDC)) {
+            if (!(t == Token.TK_S || t == Token.TK_CDO || t == Token.TK_CDC)) {
                 break;
             }
         }
@@ -1866,7 +1870,7 @@ public class CSSParser {
     }
 
     private void error(CSSParseException e, String what, boolean rethrowEOF) {
-        if (! e.isCallerNotified()) {
+        if (!e.isCallerNotified()) {
             String message = e.getMessage() + " Skipping " + what + ".";
             _errorHandler.error(_URI, message);
         }
@@ -1904,7 +1908,7 @@ public class CSSParser {
                     }
                     break;
                 case Token.SEMICOLON:
-                    if (braces == 0 && ((! needBlock) || foundBlock)) {
+                    if (braces == 0 && ((!needBlock) || foundBlock)) {
                         break LOOP;
                     }
                     break;
@@ -1942,7 +1946,7 @@ public class CSSParser {
         switch (t.getType()) {
             case Token.STRING:
                 count = _lexer.yylength();
-                return processEscapes(_lexer.yytext().toCharArray(), 1, count-1);
+                return processEscapes(_lexer.yytext().toCharArray(), 1, count - 1);
             case Token.HASH:
                 count = _lexer.yylength();
                 return processEscapes(_lexer.yytext().toCharArray(), 1, count);
@@ -1956,7 +1960,7 @@ public class CSSParser {
                 if (ch[start] == '\'' || ch[start] == '"') {
                     start++;
                 }
-                int end = ch.length-2;
+                int end = ch.length - 2;
                 while (ch[end] == '\t' || ch[end] == '\r' ||
                         ch[end] == '\n' || ch[end] == '\f') {
                     end--;
@@ -1965,13 +1969,13 @@ public class CSSParser {
                     end--;
                 }
 
-                String uriResult = processEscapes(ch, start, end+1);
+                String uriResult = processEscapes(ch, start, end + 1);
                 String uriResolved = ThreadCtx.get().sharedContext().getUserAgentCallback().resolveUri(_URI, uriResult);
 
                 if (uriResolved == null) {
                     XRLog.log(Level.INFO, LogMessageId.LogMessageId1Param.LOAD_URI_RESOLVER_REJECTED_RESOLVING_URI_AT_URI_IN_CSS_STYLESHEET, uriResult);
                 }
-                
+
                 return uriResolved == null ? "" : uriResolved;
             case Token.AT_RULE:
             case Token.IDENT:
@@ -1979,7 +1983,7 @@ public class CSSParser {
                 start = t.getType() == Token.AT_RULE ? 1 : 0;
                 count = _lexer.yylength();
                 String result = processEscapes(_lexer.yytext().toCharArray(), start, count);
-                if (! literal) {
+                if (!literal) {
                     result = result.toLowerCase();
                 }
                 return result;
@@ -2004,18 +2008,18 @@ public class CSSParser {
 
             if (c == '\\') {
                 // eat escaped newlines and handle te\st == test situations
-                if (i < end - 2 && (ch[i+1] == '\r' && ch[i+2] == '\n')) {
+                if (i < end - 2 && (ch[i + 1] == '\r' && ch[i + 2] == '\n')) {
                     i += 2;
                     continue;
                 } else {
-                    if ((i+1) < ch.length && (ch[i+1] == '\n' || ch[i+1] == '\r' || ch[i+1] == '\f')) {
+                    if ((i + 1) < ch.length && (ch[i + 1] == '\n' || ch[i + 1] == '\r' || ch[i + 1] == '\f')) {
                         i++;
                         continue;
-                    } else if ((i+1) >= ch.length) {
-                       // process \ escaped (\\)
-                       result.append(c);
-                       continue;
-                    } else if (! isHexChar(ch[i+1])) {
+                    } else if ((i + 1) >= ch.length) {
+                        // process \ escaped (\\)
+                        result.append(c);
+                        continue;
+                    } else if (!isHexChar(ch[i + 1])) {
                         continue;
                     }
                 }
@@ -2028,17 +2032,17 @@ public class CSSParser {
 
                 int cvalue = Integer.parseInt(new String(ch, current, i - current), 16);
                 if (cvalue < 0xFFFF) {
-                    result.append((char)cvalue);
+                    result.append((char) cvalue);
                 }
 
                 i--;
 
-                if (i < end - 2 && (ch[i+1] == '\r' && ch[i+2] == '\n')) {
+                if (i < end - 2 && (ch[i + 1] == '\r' && ch[i + 2] == '\n')) {
                     i += 2;
                 } else if (i < end - 1 &&
-                        (ch[i+1] == ' ' || ch[i+1] == '\t' ||
-                                ch[i+1] == '\n' || ch[i+1] == '\r' ||
-                                ch[i+1] == '\f')) {
+                        (ch[i + 1] == ' ' || ch[i + 1] == '\t' ||
+                                ch[i + 1] == '\n' || ch[i + 1] == '\r' ||
+                                ch[i + 1] == '\f')) {
                     i++;
                 }
             } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -409,18 +409,16 @@ public class CSSParser {
                     t = next();
                     if (t == Token.TK_LBRACE) {
                         skip_whitespace();
-                        LOOP:
                         while (true) {
                             t = nextWithSave();
                             if (t == null) {
                                 break;
                             }
-                            switch (t.getType()) {
-                                case Token.RBRACE:
-                                    next();
-                                    break LOOP;
-                                default:
-                                    ruleset(mediaRule);
+                            if (t.getType() == Token.RBRACE) {
+                                next();
+                                break;
+                            } else {
+                                ruleset(mediaRule);
                             }
                         }
                         skip_whitespace();
@@ -480,7 +478,6 @@ public class CSSParser {
                     // Prevent runaway threads with a max loop/counter
                     int maxLoops = 1 * 1024 * 1024; // 1M is too much, 1K is probably too...
                     int i = 0;
-                    LOOP:
                     while (true) {
                         if (++i >= maxLoops)
                             throw new CSSParseException(t, Token.TK_RBRACE, getCurrentLine());
@@ -489,7 +486,7 @@ public class CSSParser {
                         if (t == Token.TK_RBRACE) {
                             next();
                             skip_whitespace();
-                            break LOOP;
+                            break;
                         } else {
                             declaration_list(ruleset, false, true, true);
                         }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -300,9 +300,6 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         if (!(type.isEmpty() || type.equals("text/css"))) {
             return null;
         }
-
-        StylesheetInfo info = new StylesheetInfo();
-
         if (type.isEmpty()) {
             /* March 2024: https://archive.is/iuX5T
             "given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice"
@@ -310,8 +307,9 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
             type = "text/css";
             XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.CSS_PARSE_LINK_TYPE_UNSPECIFIED, link.getAttribute("href"));
         }
-        info.setType(type);
 
+        StylesheetInfo info = new StylesheetInfo();
+        info.setType(type);
         info.setOrigin(StylesheetInfo.AUTHOR);
         info.setUri(link.getAttribute("href"));
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -53,6 +53,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
      * Description of the Field
      */
     final static String _namespace = "http://www.w3.org/1999/xhtml";
+    private final static String PATH_TO_DEFAULT_STYLESHEET = "/resources/css/XhtmlNamespaceHandler.css";
 
     private static StylesheetInfo _defaultStylesheet;
     private static boolean _defaultStylesheetError = false;
@@ -377,15 +378,14 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
             info.setMedia("all");
             info.setType("text/css");
 
-            InputStream is = null;
+            InputStream inputStream = null;
             try {
-                is = getDefaultStylesheetStream();
-
+                inputStream = getDefaultStylesheetStream();
                 if (_defaultStylesheetError) {
                     return null;
                 }
 
-                try (Reader reader = new InputStreamReader(is)) {
+                try (Reader reader = new InputStreamReader(inputStream)) {
                     Stylesheet sheet = factory.parse(reader, info);
                     info.setStylesheet(sheet);
                 }
@@ -393,25 +393,20 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
                 _defaultStylesheetError = true;
                 XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_COULD_NOT_PARSE_DEFAULT_STYLESHEET, e);
             } finally {
-                OpenUtil.closeQuietly(is);
-                is = null;
+                OpenUtil.closeQuietly(inputStream);
             }
 
             _defaultStylesheet = info;
-
             return _defaultStylesheet;
         }
     }
 
     private InputStream getDefaultStylesheetStream() {
-        InputStream stream = null;
-        String defaultStyleSheet = "/resources/css/XhtmlNamespaceHandler.css";
-        stream = this.getClass().getResourceAsStream(defaultStyleSheet);
+        InputStream stream = this.getClass().getResourceAsStream(PATH_TO_DEFAULT_STYLESHEET);
         if (stream == null) {
-            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_DEFAULT_CSS, defaultStyleSheet);
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_COULD_NOT_LOAD_DEFAULT_CSS, PATH_TO_DEFAULT_STYLESHEET);
             _defaultStylesheetError = true;
         }
-
         return stream;
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -52,7 +52,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
     /**
      * Description of the Field
      */
-    final static String _namespace = "http://www.w3.org/1999/xhtml";
+    private final static String XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
     private final static String PATH_TO_DEFAULT_STYLESHEET = "/resources/css/XhtmlNamespaceHandler.css";
 
     private static StylesheetInfo _defaultStylesheet;
@@ -67,7 +67,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
      */
     @Override
     public String getNamespace() {
-        return _namespace;
+        return XHTML_NAMESPACE;
     }
 
     /**
@@ -373,7 +373,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
             }
 
             StylesheetInfo info = new StylesheetInfo();
-            info.setUri(getNamespace());
+            info.setUri("classpath:" + PATH_TO_DEFAULT_STYLESHEET);
             info.setOrigin(StylesheetInfo.USER_AGENT);
             info.setMedia("all");
             info.setType("text/css");

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -289,23 +289,25 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
 
     protected StylesheetInfo readLinkElement(Element link) {
         String rel = link.getAttribute("rel").toLowerCase();
-        if (rel.indexOf("alternate") != -1) {
+        if (rel.contains("alternate")) {
             return null;
         }//DON'T get alternate stylesheets
-        if (rel.indexOf("stylesheet") == -1) {
+        if (!rel.contains("stylesheet")) {
             return null;
         }
 
         String type = link.getAttribute("type");
-        if (! (type.equals("") || type.equals("text/css"))) {
+        if (!(type.isEmpty() || type.equals("text/css"))) {
             return null;
         }
 
         StylesheetInfo info = new StylesheetInfo();
 
-        if (type.equals("")) {
+        if (type.isEmpty()) {
             type = "text/css";
-        } // HACK is not entirely correct because default may be set by META tag or HTTP headers
+            // HACK: This is not entirely correct because default may be set by META tag or HTTP headers
+            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.CSS_PARSE_LINK_TYPE_UNSPECIFIED, link.getAttribute("href"));
+        }
         info.setType(type);
 
         info.setOrigin(StylesheetInfo.AUTHOR);
@@ -334,17 +336,17 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         //get the link elements
         Element html = doc.getDocumentElement();
         Element head = findFirstChild(html, "head");
-        if (head != null) {
+        if (head != null) { // March 2024: HTML spec disallows HTMLStyleElement outside HTMLHeadElement because it is "Metadata content"
             Node current = head.getFirstChild();
             while (current != null) {
                 if (current.getNodeType() == Node.ELEMENT_NODE) {
                     Element elem = (Element)current;
                     StylesheetInfo info = null;
                     String elemName = elem.getLocalName();
-                    if (elemName == null)
-                    {
+                    if (elemName == null) {
                         elemName = elem.getTagName();
                     }
+
                     if (elemName.equals("link")) {
                         info = readLinkElement(elem);
                     } else if (elemName.equals("style")) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -304,9 +304,11 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         StylesheetInfo info = new StylesheetInfo();
 
         if (type.isEmpty()) {
+            /* March 2024: https://archive.is/iuX5T
+            "given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice"
+            We can expect "text/css" MIME type since the "stylesheet" relationship has already been established. */
             type = "text/css";
-            // HACK: This is not entirely correct because default may be set by META tag or HTTP headers
-            XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.CSS_PARSE_LINK_TYPE_UNSPECIFIED, link.getAttribute("href"));
+            XRLog.log(Level.FINE, LogMessageId.LogMessageId1Param.CSS_PARSE_LINK_TYPE_UNSPECIFIED, link.getAttribute("href"));
         }
         info.setType(type);
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -261,9 +261,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
 
     protected StylesheetInfo readStyleElement(Element style) {
         StylesheetInfo info = new StylesheetInfo();
-        String media = style.getAttribute("media");
-
-        info.setMedia(media);
+        info.setMedia(style.getAttribute("media"));
         info.setType(style.getAttribute("type"));
         info.setTitle(style.getAttribute("title"));
         info.setOrigin(StylesheetInfo.AUTHOR);
@@ -278,13 +276,12 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         }
 
         String css = buf.toString().trim();
-        if (css.length() > 0) {
-            info.setContent(css);
-
-            return info;
-        } else {
+        if (css.isEmpty()) {
             return null;
         }
+
+        info.setContent(css);
+        return info;
     }
 
     protected StylesheetInfo readLinkElement(Element link) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/simple/extend/XhtmlCssOnlyNamespaceHandler.java
@@ -18,30 +18,21 @@
  */
 package com.openhtmltopdf.simple.extend;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-
-import com.openhtmltopdf.util.LogMessageId;
-import com.openhtmltopdf.util.OpenUtil;
-
-import org.w3c.dom.CharacterData;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.Text;
-
 import com.openhtmltopdf.css.extend.StylesheetFactory;
 import com.openhtmltopdf.css.sheet.Stylesheet;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.simple.NoNamespaceHandler;
+import com.openhtmltopdf.util.LogMessageId;
+import com.openhtmltopdf.util.OpenUtil;
 import com.openhtmltopdf.util.XRLog;
+import org.w3c.dom.CharacterData;
+import org.w3c.dom.*;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.*;
+import java.util.logging.Level;
 
 /**
  * Handles xhtml but only css styling is honored,
@@ -102,7 +93,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
     protected boolean isInteger(String value) {
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
-            if (! (c >= '0' && c <= '9')) {
+            if (!(c >= '0' && c <= '9')) {
                 return false;
             }
         }
@@ -121,13 +112,14 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         while (current != null) {
             short nodeType = current.getNodeType();
             if (nodeType == Node.TEXT_NODE || nodeType == Node.CDATA_SECTION_NODE) {
-                Text t = (Text)current;
+                Text t = (Text) current;
                 result.append(t.getData());
             }
             current = current.getNextSibling();
         }
         return result.toString();
     }
+
     private static String collapseWhiteSpace(String text) {
         StringBuilder result = new StringBuilder();
         int l = text.length();
@@ -137,7 +129,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
                 result.append(' ');
                 while (++i < l) {
                     c = text.charAt(i);
-                    if (! Character.isWhitespace(c)) {
+                    if (!Character.isWhitespace(c)) {
                         i--;
                         break;
                     }
@@ -148,6 +140,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         }
         return result.toString();
     }
+
     /**
      * Gets the linkUri attribute of the XhtmlNamespaceHandler object
      *
@@ -171,6 +164,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         }
         return null;
     }
+
     /**
      * Gets the elementStyling attribute of the XhtmlNamespaceHandler object
      *
@@ -253,7 +247,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         for (int i = 0; i < children.getLength(); i++) {
             Node n = children.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE && n.getNodeName().equals(targetName)) {
-                return (Element)n;
+                return (Element) n;
             }
         }
 
@@ -271,7 +265,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
         Node current = style.getFirstChild();
         while (current != null) {
             if (current instanceof CharacterData) {
-                buf.append(((CharacterData)current).getData());
+                buf.append(((CharacterData) current).getData());
             }
             current = current.getNextSibling();
         }
@@ -338,7 +332,7 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
             Node current = head.getFirstChild();
             while (current != null) {
                 if (current.getNodeType() == Node.ELEMENT_NODE) {
-                    Element elem = (Element)current;
+                    Element elem = (Element) current;
                     StylesheetInfo info = null;
                     String elemName = elem.getLocalName();
                     if (elemName == null) {
@@ -420,17 +414,16 @@ public class XhtmlCssOnlyNamespaceHandler extends NoNamespaceHandler {
             Node current = head.getFirstChild();
             while (current != null) {
                 if (current.getNodeType() == Node.ELEMENT_NODE) {
-                    Element elem = (Element)current;
+                    Element elem = (Element) current;
                     String elemName = elem.getLocalName();
-                    if (elemName == null)
-                    {
+                    if (elemName == null) {
                         elemName = elem.getTagName();
                     }
                     if (elemName.equals("meta")) {
                         String http_equiv = elem.getAttribute("http-equiv");
                         String content = elem.getAttribute("content");
 
-                        if(!http_equiv.equals("") && !content.equals("")) {
+                        if (!http_equiv.equals("") && !content.equals("")) {
                             metadata.put(http_equiv, content);
                         }
                     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -206,7 +206,7 @@ public interface LogMessageId {
     }
 
     enum LogMessageId2Param implements LogMessageId {
-        CSS_PARSE_TOO_MANY_STYLESHEET_IMPORTS(XRLog.CSS_PARSE, "Gave up after {} attempts to load stlyesheet at {} to avoid possible loop"),
+        CSS_PARSE_TOO_MANY_STYLESHEET_IMPORTS(XRLog.CSS_PARSE, "Gave up after {} attempts to load stylesheet at {} to avoid possible loop"),
         CSS_PARSE_COULDNT_PARSE_STYLESHEET_AT_URI(XRLog.CSS_PARSE, "Couldn't parse stylesheet at URI {}: {}"),
         CSS_PARSE_GENERIC_MESSAGE(XRLog.CSS_PARSE, "({}) {}"),
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -92,6 +92,7 @@ public interface LogMessageId {
     enum LogMessageId1Param implements LogMessageId {
         CSS_PARSE_REMOVING_STYLESHEET_URI_FROM_CACHE_BY_REQUEST(XRLog.CSS_PARSE, "Removing stylesheet '{}' from cache by request."),
         CSS_PARSE_REQUESTED_REMOVING_STYLESHEET_URI_NOT_IN_CACHE(XRLog.CSS_PARSE, "Requested removing stylesheet '{}', but it's not in cache."),
+        CSS_PARSE_LINK_TYPE_UNSPECIFIED(XRLog.CSS_PARSE, "Link type unspecified (href=\"{}\"). Using \"text/css\" as default."),
 
         XML_ENTITIES_SAX_FEATURE_NOT_SUPPORTED(XRLog.XML_ENTITIES, "SAX feature not supported on this XMLReader: {}"),
         XML_ENTITIES_SAX_FEATURE_NOT_RECOGNIZED(XRLog.XML_ENTITIES, "SAX feature not recognized on this XMLReader: {}. Feature may be properly named, but not recognized by this parser."),

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -3,8 +3,11 @@ package com.openhtmltopdf.util;
 public interface LogMessageId {
 
     Enum<?> getEnum();
+
     String getWhere();
+
     String getMessageFormat();
+
     String formatMessage(Object[] args);
 
     enum LogMessageId0Param implements LogMessageId {
@@ -58,7 +61,6 @@ public interface LogMessageId {
         EXCEPTION_COULD_NOT_READ_PDF_AS_SRC_FOR_IMG(XRLog.EXCEPTION, "Could not read pdf passed as src for img element!"),
         EXCEPTION_COULD_NOT_PARSE_DEFAULT_STYLESHEET(XRLog.EXCEPTION, "Could not parse default stylesheet"),
         EXCEPTION_SELECTOR_BAD_SIBLING_AXIS(XRLog.EXCEPTION, "Bad sibling axis");
-        
 
         private final String where;
         private final String messageFormat;
@@ -127,7 +129,7 @@ public interface LogMessageId {
         LOAD_COULD_NOT_LOAD_PREFERRED_XML(XRLog.LOAD, "Could not load preferred XML {}, using default which may not be secure."),
         LOAD_LOADED_DOCUMENT_TIME(XRLog.LOAD, "Loaded document in ~{}ms"),
         LOAD_SAX_XMLREADER_IN_USE(XRLog.LOAD, "SAX XMLReader in use (parser): {}"),
-        LOAD_XMLREADER_CLASS_SPECIFIED_COULD_NOT_BE_FOUND(XRLog.LOAD,"The XMLReader class you specified as a configuration property " +
+        LOAD_XMLREADER_CLASS_SPECIFIED_COULD_NOT_BE_FOUND(XRLog.LOAD, "The XMLReader class you specified as a configuration property " +
                 "could not be found. Class.forName() failed on " +
                 "{}. Please check classpath. Use value 'default' in " +
                 "FS configuration if necessary. Will now try JDK default."),
@@ -321,8 +323,8 @@ public interface LogMessageId {
         CASCADE_UNKNOWN_DATATYPE_FOR_RELATIVE_TO_ABSOLUTE(XRLog.CASCADE, "Asked to convert {} from relative to absolute, don't recognize the datatype '{}' {}({})"),
         CASCADE_CALC_FLOAT_PROPORTIONAL_VALUE_INFO_FONT_SIZE(XRLog.CASCADE, "{}, relative= {} ({}), absolute= {}"),
 
-        EXCEPTION_CONFIGURATION_WRONG_TYPE(XRLog.EXCEPTION, "Property '{}' was requested as a {}, but value of '{}' is not a {}. Check configuration."),;
-
+        EXCEPTION_CONFIGURATION_WRONG_TYPE(XRLog.EXCEPTION, "Property '{}' was requested as a {}, but value of '{}' is not a {}. Check configuration."),
+        ;
 
 
         private final String where;

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
       <name>Mads Opheim</name>
       <email>mads.opheim@gmail.com</email>
     </developer>
+    <developer>
+      <id>siegelzc</id>
+      <name>Zachary Siegel</name>
+      <email>siegelzc@gmail.com</email>
+    </developer>
   </developers>
 
   <profiles>


### PR DESCRIPTION
Largely just quality-of-life changes that helped me understand the code as I was working on #17.

There are two user-facing changes. Both are log-related:

1. Changed log level for `media = <>` message from `INFO` to `FINE`
2. Added a FINE-level log message when `text/css` is inferred as the default MIME type for a linked stylesheet

After this PR is approved, I would like to go ahead and run my IDE's formatter over the files I touched, but I want to wait to do that until after people have had the chance to look at it unobstructed.