### PR TITLE
Don't publish Maven artifacts for modules that were not published ear…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
               <publishingServerId>central</publishingServerId>
               <tokenAuth>true</tokenAuth>
               <autoPublish>true</autoPublish>
+              <excludeArtifacts>
+                <excludeArtifact>openhtmltopdf-examples</excludeArtifact>
+                <excludeArtifact>openhtmltopdf-pdfa-testing</excludeArtifact>
+                <excludeArtifact>openhtmltopdf-templates</excludeArtifact>
+              </excludeArtifacts>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Don't publish Maven artifacts for modules that were not published earlier on.

There's config in these modules to make them skip Maven deploy, but the new Maven publishing plugin doesn't care about that config, so using the new exclude artifacts mechanism