### PR TITLE
Use release workflow badge instead of build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![build](https://github.com/openhtmltopdf/openhtmltopdf/workflows/build/badge.svg)](https://github.com/openhtmltopdf/openhtmltopdf/actions?query=workflow%3Abuild)
+[![build-release](https://github.com/openhtmltopdf/openhtmltopdf/workflows/release/badge.svg)](https://github.com/openhtmltopdf/openhtmltopdf/actions?query=workflow%3Arelease)
 
 # OPEN HTML TO PDF
 


### PR DESCRIPTION
The build workflow is run for each pull request, so it shows the "failing" state when a pull request fails to build, but what we care about is the health of the `main` branch.

The release workflow is what builds and tests the code on the `main` branch, using `mvn package ...`.