### PR TITLE
Support for custom hyphenators

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -908,9 +908,6 @@ public final class CSSName implements Comparable<CSSName> {
                     new PrimitivePropertyBuilders.Overflow()
             );
 
-    /**
-     * Unique CSSName instance for CSS2 property.
-     */
     public final static CSSName HYPHENS =
             addProperty(
                     "hyphens",

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/CSSName.java
@@ -911,6 +911,18 @@ public final class CSSName implements Comparable<CSSName> {
     /**
      * Unique CSSName instance for CSS2 property.
      */
+    public final static CSSName HYPHENS =
+            addProperty(
+                    "hyphens",
+                    PRIMITIVE,
+                    "manual",
+                    INHERITS,
+                    new PrimitivePropertyBuilders.Hyphens()
+            );
+
+    /**
+     * Unique CSSName instance for CSS2 property.
+     */
     public final static CSSName PAGE =
             addProperty(
                     "page",

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
@@ -132,6 +132,7 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue LOWERCASE = addValue("lowercase");
     public final static IdentValue LTR = addValue("ltr");
     public final static IdentValue MARKER = addValue("marker");
+    public final static IdentValue MANUAL = addValue("manual");
     public final static IdentValue MIDDLE = addValue("middle");
     public final static IdentValue NO_CLOSE_QUOTE = addValue("no-close-quote");
     public final static IdentValue NO_OPEN_QUOTE = addValue("no-open-quote");

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/constants/IdentValue.java
@@ -131,8 +131,8 @@ public class IdentValue implements FSDerivedValue {
     public final static IdentValue LOWER_ROMAN = addValue("lower-roman");
     public final static IdentValue LOWERCASE = addValue("lowercase");
     public final static IdentValue LTR = addValue("ltr");
-    public final static IdentValue MARKER = addValue("marker");
     public final static IdentValue MANUAL = addValue("manual");
+    public final static IdentValue MARKER = addValue("marker");
     public final static IdentValue MIDDLE = addValue("middle");
     public final static IdentValue NO_CLOSE_QUOTE = addValue("no-close-quote");
     public final static IdentValue NO_OPEN_QUOTE = addValue("no-open-quote");

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/property/PrimitivePropertyBuilders.java
@@ -1126,6 +1126,17 @@ public class PrimitivePropertyBuilders {
         }
     }
 
+    public static class Hyphens extends SingleIdent {
+        // auto | none | manual
+        private static final BitSet ALLOWED = setFor(
+                new IdentValue[] { IdentValue.AUTO, IdentValue.NONE, IdentValue.MANUAL });
+
+        @Override
+        protected BitSet getAllowed() {
+            return ALLOWED;
+        }
+    }
+
     public static class PaddingTop extends NonNegativeLengthLike {
     }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
@@ -1,0 +1,8 @@
+package com.openhtmltopdf.extend;
+
+/**
+ * Interface for a custom hyphenation implementation.
+ */
+public interface Hyphenator {
+    String hyphenateText(String text);
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
@@ -5,5 +5,12 @@ package com.openhtmltopdf.extend;
  */
 @FunctionalInterface
 public interface Hyphenator {
+    /**
+     * Hyphenates a given String by inserting soft-hyphens
+     * at desired hyphenation points and returns the result.
+     *
+     * @param text String to hyphenate
+     * @return with soft-hyphens hyphenated String
+     */
     String hyphenateText(String text);
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/Hyphenator.java
@@ -3,6 +3,7 @@ package com.openhtmltopdf.extend;
 /**
  * Interface for a custom hyphenation implementation.
  */
+@FunctionalInterface
 public interface Hyphenator {
     String hyphenateText(String text);
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/InlineBoxing.java
@@ -37,6 +37,7 @@ import com.openhtmltopdf.css.style.CalculatedStyle;
 import com.openhtmltopdf.css.style.CssContext;
 import com.openhtmltopdf.css.style.derived.BorderPropertySet;
 import com.openhtmltopdf.css.style.derived.RectPropertySet;
+import com.openhtmltopdf.extend.Hyphenator;
 import com.openhtmltopdf.layout.Breaker.BreakTextResult;
 import com.openhtmltopdf.render.AnonymousBlockBox;
 import com.openhtmltopdf.render.BlockBox;
@@ -84,6 +85,7 @@ public class InlineBoxing {
         Element blockElement = box.getElement();
         Paragraph para = c.getParagraphSplitter().lookupBlockElement(blockElement);
         byte blockLayoutDirection = para.getActualDirection();
+        Hyphenator hyphenator = c.getSharedContext().getHyphenator();
 
         SpaceVariables space = new SpaceVariables(box.getContentWidth());
         StateVariables current = new StateVariables();
@@ -146,6 +148,10 @@ public class InlineBoxing {
                 InlineBox inlineBox = (InlineBox)node;
 
                 CalculatedStyle style = inlineBox.getStyle();
+
+                if (hyphenator != null && IdentValue.AUTO.equals(style.getIdent(CSSName.HYPHENS))) {
+                    inlineBox.setText(hyphenator.hyphenateText(inlineBox.getText()));
+                }
 
                 if (inlineBox.hasFootnote() && c.isPrint()) {
                     c.getFootnoteManager().addFootnoteBody(c, inlineBox.getFootnoteBody(), current.line);

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
@@ -110,6 +110,7 @@ public class SharedContext {
 	private String replacementText = "#";
 	private FSTextBreaker lineBreaker = new UrlAwareLineBreakIterator(BreakIterator.getLineInstance(Locale.US));
 	private FSTextBreaker characterBreaker = new TextUtil.DefaultCharacterBreaker(BreakIterator.getCharacterInstance(Locale.US));
+    private Hyphenator hyphenator;
 
 	private FSTextTransformer _unicodeToLowerTransformer = new TextUtil.DefaultToLowerTransformer(Locale.US);
 	private FSTextTransformer _unicodeToUpperTransformer = new TextUtil.DefaultToUpperTransformer(Locale.US);
@@ -527,6 +528,14 @@ public class SharedContext {
 	public void setCharacterBreaker(FSTextBreaker breaker) {
 		this.characterBreaker = breaker;
 	}
+
+    public void setHyphenator(Hyphenator hyphenator) {
+        this.hyphenator = hyphenator;
+    }
+
+    public Hyphenator getHyphenator() {
+        return this.hyphenator;
+    }
 	
 	
 	/**

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/BaseRendererBuilder.java
@@ -70,6 +70,7 @@ public abstract class BaseRendererBuilder<TFinalClass extends BaseRendererBuilde
 		public String _preferredTransformerFactoryImplementationClass = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
 		public String _preferredDocumentBuilderFactoryImplementationClass = "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl";
 		public Consumer<Diagnostic> _diagnosticConsumer;
+		public Hyphenator _hyphenator;
     }
 
 	protected final TBaseRendererBuilderState state;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxRenderer.java
@@ -135,6 +135,8 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
 
     private final Closeable _diagnosticConsumer;
 
+    private Hyphenator _hyphenator;
+
     private final int _initialPageNumber;
 
     /**
@@ -166,6 +168,8 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
             _pdfAConformance = state._pdfAConformance;
             _pdfUaConformance = state._pdfUaConform;
             _colorProfile = state._colorProfile;
+
+            _hyphenator = state._hyphenator;
 
             _dotsPerPoint = DEFAULT_DOTS_PER_POINT;
             _testMode = state._testMode;
@@ -247,6 +251,10 @@ public class PdfBoxRenderer implements Closeable, PageSupplier {
 
             if (unicode.toTitleTransformer != null) {
                 _sharedContext.setUnicodeToTitleTransformer(unicode.toTitleTransformer);
+            }
+
+            if(_hyphenator != null) {
+                _sharedContext.setHyphenator(_hyphenator);
             }
 
             this._defaultTextDirection = unicode.textDirection ? BidiSplitter.RTL : BidiSplitter.LTR;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -4,6 +4,7 @@ import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.extend.FSCacheEx;
 import com.openhtmltopdf.extend.FSCacheValue;
 import com.openhtmltopdf.extend.FSSupplier;
+import com.openhtmltopdf.extend.Hyphenator;
 import com.openhtmltopdf.extend.impl.FSNoOpCacheStore;
 import com.openhtmltopdf.outputdevice.helper.*;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontGroup;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -251,6 +251,15 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	}
 
 	/**
+	 * Provide a custom auto-hyphenator, that will be used, if the 'hyphens' is being used in css
+	 * @param hyphenator custom hyphenator, that should be used
+	 */
+	public PdfRendererBuilder useHyphenation(Hyphenator hyphenator) {
+		state._hyphenator = hyphenator;
+		return this;
+	}
+
+	/**
 	 * List of caches available.
 	 */
 	public enum CacheStore {


### PR DESCRIPTION
The addition is intended to give the user the option to add their own hyphenator, similar to the dom mutators and svg support.
So, I added the required values for the css paser and also an interface for the hyphenator implementations.
Currently all blocks, that have the css property "hyphens" set to "auto" will be hyphenated entirely.
The hyphenator should only add soft-hyphens to the words on the intended hyphenation points, after that the already existing soft-hyphen support takes care of the rest.

I could provide the hyphenator implementation, I used for testing, in an additional "utils"-module, since I used the hyphenation algorithm from Apache FOP, which uses TeX hyphenation patterns.
Performance-wise it didn't have much of an impact in my test cases, after FOP loaded the patterns.