### PR TITLE
Accessibility typo

### DIFF
--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/PdfUaTestcaseRunnerTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/PdfUaTestcaseRunnerTest.java
@@ -47,7 +47,7 @@ public class PdfUaTestcaseRunnerTest {
             PdfRendererBuilder builder = new PdfRendererBuilder();
             builder.useFastMode();
             builder.testMode(true);
-            builder.usePdfUaAccessbility(true);
+            builder.usePdfUaAccessibility(true);
             builder.useFont(new File("target/test/visual-tests/Karla-Bold.ttf"), "TestFont");
             builder.withHtmlContent(html, PdfUaTestcaseRunnerTest.class.getResource("/testcases/pdfua/").toString());
             builder.toStream(os);

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfRendererBuilder.java
@@ -191,7 +191,7 @@ public class PdfRendererBuilder extends BaseRendererBuilder<PdfRendererBuilder, 
 	 * @param pdfUaAccessibility
 	 * @return this for method chaining
 	 */
-	public PdfRendererBuilder usePdfUaAccessbility(boolean pdfUaAccessibility) {
+	public PdfRendererBuilder usePdfUaAccessibility(boolean pdfUaAccessibility) {
 	    this.state._pdfUaConform = pdfUaAccessibility;
 	    return this;
 	}


### PR DESCRIPTION
Fixes a typo in the `PdfRendererBuilder` API.

See: https://github.com/danfickle/openhtmltopdf/pull/870