### PR TITLE
Create named destinations for boxes with -fs-named-destination: create

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -20,6 +20,7 @@
 package com.openhtmltopdf.css.parser;
 
 import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.constants.MarginBoxName;
 import com.openhtmltopdf.css.constants.SVGProperty;
 import com.openhtmltopdf.css.extend.TreeResolver;
@@ -1331,6 +1332,10 @@ public class CSSParser {
                     }
 
                     if (valid) {
+                        if (cssName == CSSName.FS_NAMED_DESTINATION && values.stream().anyMatch(propertyValue -> IdentValue.valueOf(propertyValue.getStringValue()) == IdentValue.CREATE)) {
+                            ThreadCtx.get().sharedContext().setUsingFsNamedDestination(true);
+                        }
+
                         try {
                             PropertyBuilder builder = CSSName.getPropertyBuilder(cssName);
                             ruleset.addAllProperties(builder.buildDeclarations(

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/SharedContext.java
@@ -116,6 +116,11 @@ public class SharedContext {
 	private FSTextTransformer _unicodeToUpperTransformer = new TextUtil.DefaultToUpperTransformer(Locale.US);
 	private FSTextTransformer _unicodeToTitleTransformer = new TextUtil.DefaultToTitleTransformer();
 
+    /**
+     * A flag to indicate that named boxes should be checked for creating named destinations
+     */
+    private boolean usingFsNamedDestination;
+
 	public String _preferredTransformerFactoryImplementationClass = null;
 	public String _preferredDocumentBuilderFactoryImplementationClass = null;
 
@@ -577,6 +582,14 @@ public class SharedContext {
 	public void setUnicodeToTitleTransformer(FSTextTransformer tr) {
 		this._unicodeToTitleTransformer = tr;
 	}
+
+    public boolean isUsingFsNamedDestination() {
+        return usingFsNamedDestination;
+    }
+
+    public void setUsingFsNamedDestination(boolean usingFsNamedDestination) {
+        this.usingFsNamedDestination = usingFsNamedDestination;
+    }
 
     public RootCounterContext getGlobalCounterContext() {
         return _rootCounterContext;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/util/LogMessageId.java
@@ -60,7 +60,8 @@ public interface LogMessageId {
         EXCEPTION_TRIED_TO_OPEN_A_PASSWORD_PROTECTED_DOCUMENT_AS_SRC_FOR_IMG(XRLog.EXCEPTION, "Tried to open a password protected document as src for an img!"),
         EXCEPTION_COULD_NOT_READ_PDF_AS_SRC_FOR_IMG(XRLog.EXCEPTION, "Could not read pdf passed as src for img element!"),
         EXCEPTION_COULD_NOT_PARSE_DEFAULT_STYLESHEET(XRLog.EXCEPTION, "Could not parse default stylesheet"),
-        EXCEPTION_SELECTOR_BAD_SIBLING_AXIS(XRLog.EXCEPTION, "Bad sibling axis");
+        EXCEPTION_SELECTOR_BAD_SIBLING_AXIS(XRLog.EXCEPTION, "Bad sibling axis"),
+        EXCEPTION_INVALID_DESTS_ARRAY(XRLog.EXCEPTION, "Invalid dests array.");
 
         private final String where;
         private final String messageFormat;

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/named-destinations-basic.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/named-destinations-basic.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+<style>
+@page {
+  size: A4;
+  margin: 0;
+}
+</style>
+</head>
+<body>
+   <div style="width: 100%; height: 20px; background-color: transparent; page-break-after: always;"></div>
+
+   <div id="secondpage" style="background-color: red; height: 10px; -fs-named-destination: create;"></div>
+   <div style="width: 100%; height: 20px; background-color: transparent; page-break-after: always;"></div>
+   <div id="thirdpage" style="background-color: green; height: 10px; -fs-named-destination: create;"></div>
+   <div style="width: 100%; height: 20px; background-color: transparent; page-break-after: always;"></div>
+   <!-- Default -fs-named-destination behaviour: none -->
+   <div id="fourthpage" style="background-color: blue; height: 10px;"></div>
+   <div style="width: 100%; height: 20px; background-color: transparent; page-break-after: always;"></div>
+   <!-- Explicit -fs-named-destination behaviour -->
+   <div id="fifthpage" style="background-color: yellow; height: 10px; -fs-named-destination: none;"></div>
+</body>
+</html>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastOutputDevice.java
@@ -182,6 +182,9 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     // Link manage handles a links. We add the link in paintBackground and then output links when the document is finished.
     private PdfBoxFastLinkManager _linkManager;
 
+    // Named destination manager, to track where we have named destinations to create which are then written when the document is finished.
+    private PdfBoxNamedDestinationManager _namedDestinationManager;
+
     // Not used currently.
     private RenderingContext _renderingContext;
 
@@ -878,6 +881,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
     public void start(Document doc) {
         _bmManager = new PdfBoxBookmarkManager(doc, _writer, _sharedContext, _dotsPerPoint, this);
         _linkManager = new PdfBoxFastLinkManager(_sharedContext, _dotsPerPoint, _root, this);
+        _namedDestinationManager = new PdfBoxNamedDestinationManager(_writer, _sharedContext, _dotsPerPoint, this);
         loadMetadata(doc);
         
         if (_pdfUaConform) {
@@ -899,6 +903,7 @@ public class PdfBoxFastOutputDevice extends AbstractOutputDevice implements Outp
         // Also need access to the structure tree.
 		processControls(c);
         _linkManager.processLinks(_pdfUa);
+        _namedDestinationManager.processNamedDestinations(c, root);
         
         if (_pdfUa != null) {
             _pdfUa.finishNumberTree();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxNamedDestinationManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxNamedDestinationManager.java
@@ -1,0 +1,73 @@
+package com.openhtmltopdf.pdfboxout;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.constants.IdentValue;
+import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.render.Box;
+import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.util.LogMessageId;
+import com.openhtmltopdf.util.XRLog;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.pdmodel.PDDestinationNameTreeNode;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageDestination;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+
+public class PdfBoxNamedDestinationManager {
+
+    private final PDDocument _writer;
+    private final SharedContext _sharedContext;
+    private final float _dotsPerPoint;
+    private final PdfBoxFastOutputDevice _od;
+
+    public PdfBoxNamedDestinationManager(PDDocument doc, SharedContext ctx, float dotsPerPoint, PdfBoxFastOutputDevice od) {
+        this._writer = doc;
+        this._sharedContext = ctx;
+        this._dotsPerPoint = dotsPerPoint;
+        this._od = od;
+    }
+
+    public void processNamedDestinations(RenderingContext c, Box root) {
+        Map<String, Box> idMap = _sharedContext.getIdMap();
+        if (idMap != null && !idMap.isEmpty()) {
+            Map<String, PDPageDestination> names = new LinkedHashMap<>();
+            idMap.forEach((id, box) -> {
+                if (box.getStyle().isIdent(CSSName.FS_NAMED_DESTINATION, IdentValue.CREATE)) {
+                    names.put(id, createDestination(c, box, root));
+                }
+            });
+
+            if (!names.isEmpty()) {
+                PDDocumentNameDictionary nameTree = new PDDocumentNameDictionary(_writer.getDocumentCatalog());
+                PDDestinationNameTreeNode dests = nameTree.getDests();
+                if (dests == null) {
+                    dests = new PDDestinationNameTreeNode(new COSDictionary());
+                    nameTree.setDests(dests);
+                }
+
+                try {
+                    Map<String, PDPageDestination> allNames = dests.getNames();
+                    if (allNames == null) {
+                        allNames = names;
+                    } else {
+                        allNames.putAll(names);
+                    }
+
+                    dests.setNames(allNames);
+                } catch (IOException e) {
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_INVALID_DESTS_ARRAY, e);
+                }
+            }
+        }
+    }
+
+    private PDPageXYZDestination createDestination(RenderingContext c, Box box, Box root) {
+        return PdfBoxBookmarkManager.createBoxDestination(c, _od.getWriter(), _od, _dotsPerPoint, root, box);
+    }
+}

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxNamedDestinationManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxNamedDestinationManager.java
@@ -35,15 +35,15 @@ public class PdfBoxNamedDestinationManager {
 
     public void processNamedDestinations(RenderingContext c, Box root) {
         Map<String, Box> idMap = _sharedContext.getIdMap();
-        if (idMap != null && !idMap.isEmpty()) {
-            Map<String, PDPageDestination> names = new LinkedHashMap<>();
+        if (_sharedContext.isUsingFsNamedDestination() && idMap != null && !idMap.isEmpty()) {
+            Map<String, PDPageDestination> explicitNames = new LinkedHashMap<>();
             idMap.forEach((id, box) -> {
                 if (box.getStyle().isIdent(CSSName.FS_NAMED_DESTINATION, IdentValue.CREATE)) {
-                    names.put(id, createDestination(c, box, root));
+                    explicitNames.put(id, createDestination(c, box, root));
                 }
             });
 
-            if (!names.isEmpty()) {
+            if (!explicitNames.isEmpty()) {
                 PDDocumentNameDictionary nameTree = new PDDocumentNameDictionary(_writer.getDocumentCatalog());
                 PDDestinationNameTreeNode dests = nameTree.getDests();
                 if (dests == null) {
@@ -54,9 +54,9 @@ public class PdfBoxNamedDestinationManager {
                 try {
                     Map<String, PDPageDestination> allNames = dests.getNames();
                     if (allNames == null) {
-                        allNames = names;
+                        allNames = explicitNames;
                     } else {
-                        allNames.putAll(names);
+                        allNames.putAll(explicitNames);
                     }
 
                     dests.setNames(allNames);


### PR DESCRIPTION
Fixes #69 

Adds support for `-fs-named-destination: create` from Flying Saucer, which was originally implemented in FS with the following two pull requests:

* https://github.com/flyingsaucerproject/flyingsaucer/pull/27
* https://github.com/flyingsaucerproject/flyingsaucer/pull/44

Where there is a box with an `id` attribute, and the `-fs-named-destination: create;` resolved style, it will create a named destination in the document catalog. It doesn't (currently) make any attempt to use these for (e.g.) anchor linking in order to reduce the impact of the change, but this may be useful for implementors who post-process PDFs to be able to get access to a `PDPageXYZDestination` for an id.