### PR TITLE
remove repository.apache.org

### DIFF
--- a/openhtmltopdf-objects/pom.xml
+++ b/openhtmltopdf-objects/pom.xml
@@ -3,18 +3,6 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<repositories>
-		<repository>
-			<id>ApacheSnapshot</id>
-			<name>Apache Repository</name>
-			<url>https://repository.apache.org/content/groups/snapshots/</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-
 	<parent>
 		<groupId>io.github.openhtmltopdf</groupId>
 		<artifactId>openhtmltopdf-parent</artifactId>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -3,18 +3,6 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <repositories>
-    <repository>
-      <id>ApacheSnapshot</id>
-      <name>Apache Repository</name>
-      <url>https://repository.apache.org/content/groups/snapshots/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    </repositories>
-
-
   <parent>
     <groupId>io.github.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove repository definitions referencing `repository.apache.org/.../snapshots`.  These definitions cause `openhtmltopdf` builds to hit the repo looking for the wrong artifacts.

- Non-snapshot artifact:

```
[INFO] Downloading from ApacheSnapshot: https://repository.apache.org/content/groups/snapshots/org/apache/pdfbox/pdfbox/3.0.3/pdfbox-3.0.3.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/3.0.3/pdfbox-3.0.3.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/3.0.3/pdfbox-3.0.3.pom (47 kB at 5.2 MB/s)
```

https://github.com/openhtmltopdf/openhtmltopdf/actions/runs/12214964961/job/34076353445#step:5:2621

- Non-Apache artifact:

```
[INFO] Downloading from ApacheSnapshot: https://repository.apache.org/content/groups/snapshots/org/junit/jupiter/junit-jupiter/5.10.1/junit-jupiter-5.10.1.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.1/junit-jupiter-5.10.1.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.1/junit-jupiter-5.10.1.pom (3.2 kB at 267 kB/s)
```

https://github.com/openhtmltopdf/openhtmltopdf/actions/runs/12214964961/job/34076353445#step:5:2663

## How was this patch tested?

```
$ mvn -B -DskipTests package
...
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/3.0.3/pdfbox-3.0.3.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/pdfbox/pdfbox/3.0.3/pdfbox-3.0.3.pom (47 kB at 1.5 MB/s)
...
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.1/junit-jupiter-5.10.1.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/jupiter/junit-jupiter/5.10.1/junit-jupiter-5.10.1.pom (3.2 kB at 139 kB/s)
...
[INFO] Reactor Summary for Openhtmltopdf 1.1.5-SNAPSHOT:
[INFO] 
[INFO] Openhtmltopdf ...................................... SUCCESS [  1.646 s]
[INFO] Openhtmltopdf Core Renderer ........................ SUCCESS [  6.251 s]
[INFO] Openhtmltopdf PDF Rendering (Apache PDF-BOX 3) ..... SUCCESS [  2.235 s]
[INFO] Openhtmltopdf slf4j Support ........................ SUCCESS [  0.941 s]
[INFO] Openhtmltopdf RTL Support .......................... SUCCESS [  0.502 s]
[INFO] Openhtmltopdf SVG Support .......................... SUCCESS [  1.726 s]
[INFO] Openhtmltopdf MathML Support ....................... SUCCESS [  1.317 s]
[INFO] Openhtmltopdf Image Rendering (Java2D) ............. SUCCESS [  0.756 s]
[INFO] Openhtmltopdf PDF Rendering (Apache PDF-BOX 3) ..... SUCCESS [  1.197 s]
[INFO] Openhtmltopdf Latex Math Support ................... SUCCESS [  1.019 s]
[INFO] Openhtmltopdf Examples ............................. SUCCESS [  8.980 s]
[INFO] Openhtmltopdf PDF/A Testing ........................ SUCCESS [  8.333 s]
[INFO] Openhtmltopdf Templates ............................ SUCCESS [  1.073 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.055 s
```