### PR TITLE
SnakeYAML major version upgrade

### DIFF
--- a/openhtmltopdf-templates/pom.xml
+++ b/openhtmltopdf-templates/pom.xml
@@ -1,100 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
-    <artifactId>openhtmltopdf-parent</artifactId>
-    <version>${revision}</version>
-  </parent>
+    <parent>
+        <groupId>io.github.openhtmltopdf</groupId>
+        <artifactId>openhtmltopdf-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
 
-  <artifactId>openhtmltopdf-templates</artifactId>
+    <artifactId>openhtmltopdf-templates</artifactId>
 
-  <packaging>jar</packaging>
+    <packaging>jar</packaging>
 
-  <name>Openhtmltopdf Templates</name>
-  <description>PDF templates and website generation for Openhtmltopdf. It is not deployed with a release.</description>
+    <name>Openhtmltopdf Templates</name>
+    <description>PDF templates and website generation for Openhtmltopdf. It is not deployed with a release.
+    </description>
 
-  <licenses>
-    <license>
-      <name>MIT</name>
-      <url>https://opensource.org/licenses/MIT</url>
-    </license>
-  </licenses>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
 
-  <dependencies>
-    <dependency>
-      <groupId>io.github.openhtmltopdf</groupId>
-      <artifactId>openhtmltopdf-pdfbox</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.github.openhtmltopdf</groupId>
-      <artifactId>openhtmltopdf-svg-support</artifactId>
-      <version>${project.version}</version>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-pdfbox</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-svg-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.thymeleaf</groupId>
-      <artifactId>thymeleaf</artifactId>
-      <version>3.0.11.RELEASE</version>
-    </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.0.11.RELEASE</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.thymeleaf.extras</groupId>
-      <artifactId>thymeleaf-extras-java8time</artifactId>
-      <version>3.0.4.RELEASE</version>
-    </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-java8time</artifactId>
+            <version>3.0.4.RELEASE</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.imgscalr</groupId>
-      <artifactId>imgscalr-lib</artifactId>
-      <version>4.2</version>
-    </dependency>
+        <dependency>
+            <groupId>org.imgscalr</groupId>
+            <artifactId>imgscalr-lib</artifactId>
+            <version>4.2</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
-    </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
-    </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.26</version>
+        </dependency>
 
-    <dependency>
-      <groupId>org.codelibs</groupId>
-      <artifactId>jhighlight</artifactId>
-      <version>1.0.3</version>
-    </dependency>
+        <dependency>
+            <groupId>org.codelibs</groupId>
+            <artifactId>jhighlight</artifactId>
+            <version>1.0.3</version>
+        </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${open.junit4.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${open.junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <use>false</use>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <use>false</use>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/openhtmltopdf-templates/pom.xml
+++ b/openhtmltopdf-templates/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
+            <version>2.4</version>
         </dependency>
 
         <dependency>

--- a/openhtmltopdf-templates/pom.xml
+++ b/openhtmltopdf-templates/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency>

--- a/openhtmltopdf-templates/src/main/java/com/openhtmltopdf/templates/Application.java
+++ b/openhtmltopdf-templates/src/main/java/com/openhtmltopdf/templates/Application.java
@@ -25,6 +25,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.ImageType;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.imgscalr.Scalr;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -72,7 +73,7 @@ public class Application {
     }
 
     private TemplateSettings getYaml(String props) {
-        Constructor cons = new Constructor(TemplateSettings.class);
+        Constructor cons = new Constructor(TemplateSettings.class, new LoaderOptions());
         Yaml yaml = new Yaml(cons);
         return yaml.load(props);
     }


### PR DESCRIPTION
Resolves:
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/2
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/3
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/4
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/5
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/6
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/7
* https://github.com/openhtmltopdf/openhtmltopdf/security/dependabot/8

Upgrades SnakeYAML 1.26 -> 2.0

This really isn't an issue because SnakeYAML is only used in the openhtmltopdf-templates module.

Note: I ran the IntelliJ formatter on the POM file before making any changes. To review the actual change, ignore the first commit on this branch.