### PR TITLE
Set `/Contents` on file annotation

### DIFF
--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -308,6 +308,10 @@ public class PdfBoxFastLinkManager {
 
             annotationFileAttachment.setFile(fs);
             annotationFileAttachment.setAppearance(this._embeddedFileAppearance);
+            String fileName = elem.getAttribute("download");
+            if ( fileName != null && !fileName.isEmpty()) {
+                annotationFileAttachment.setContents(fileName);
+            }
 
             return new AnnotationContainer.PDAnnotationFileAttachmentContainer(annotationFileAttachment);
         }
@@ -361,6 +365,7 @@ public class PdfBoxFastLinkManager {
 
                 annotationFileAttachment.setFile(fs);
                 annotationFileAttachment.setAppearance(this._embeddedFileAppearance);
+                annotationFileAttachment.setContents(fileName);
 
                 // PDF/A3 requires we explicitly list this link as associated with file.
                 if (elem.hasAttribute("relationship")) {


### PR DESCRIPTION
Fixes https://github.com/openhtmltopdf/openhtmltopdf/issues/65

The `/Contents` information is required for some PDF readers to properly display a label in the "Annotations" panel