### PR TITLE
Fix PDF/UA-1 accessibility compliance (structure tree order, running footer links, link Contents)

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
@@ -18,6 +18,7 @@ import com.openhtmltopdf.render.OperatorSetClip;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.DisplayListCollector;
 import com.openhtmltopdf.render.displaylist.TransformCreator;
+import com.openhtmltopdf.extend.StructureType;
 
 public class SimplePainter {
     private final int xTranslate;
@@ -174,18 +175,20 @@ public class SimplePainter {
     }
     
     private void paintReplacedElement(RenderingContext c, BlockBox replaced) {
-        
+
         Rectangle contentBounds = replaced.getContentAreaEdge(
                 replaced.getAbsX(), replaced.getAbsY(), c);
-        
+
         // Minor hack:  It's inconvenient to adjust for margins, border, padding during
         // layout so just do it here.
         Point loc = replaced.getReplacedElement().getLocation();
         if (contentBounds.x != loc.x || contentBounds.y != loc.y) {
             replaced.getReplacedElement().setLocation(contentBounds.x, contentBounds.y);
         }
-        
+
+        Object token = c.getOutputDevice().startStructure(StructureType.REPLACED, replaced);
         c.getOutputDevice().paintReplacedElement(c, replaced);
+        c.getOutputDevice().endStructure(token);
     }
 
     private void paintReplacedElements(RenderingContext c, List<DisplayListItem> replaceds) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
@@ -19,6 +19,7 @@ import com.openhtmltopdf.render.OperatorSetClip;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.DisplayListCollector;
 import com.openhtmltopdf.render.displaylist.TransformCreator;
+import com.openhtmltopdf.extend.StructureType;
 
 public class SimplePainter {
     private final int xTranslate;
@@ -175,20 +176,22 @@ public class SimplePainter {
     }
     
     private void paintReplacedElement(RenderingContext c, BlockBox replaced) {
-        
+
         Rectangle contentBounds = replaced.getContentAreaEdge(
                 replaced.getAbsX(), replaced.getAbsY(), c);
-        
+
         // Minor hack:  It's inconvenient to adjust for margins, border, padding during
         // layout so just do it here.
         Point loc = replaced.getReplacedElement().getLocation();
         if (contentBounds.x != loc.x || contentBounds.y != loc.y) {
             replaced.getReplacedElement().setLocation(contentBounds.x, contentBounds.y);
         }
-        
+
         // Clip to the rounded border so border-radius is honored for replaced content (e.g. images).
+        Object token = c.getOutputDevice().startStructure(StructureType.REPLACED, replaced);
         BorderPainter.paintClippedToBorderRadius(c, replaced,
                 () -> c.getOutputDevice().paintReplacedElement(c, replaced));
+        c.getOutputDevice().endStructure(token);
     }
 
     private void paintReplacedElements(RenderingContext c, List<DisplayListItem> replaceds) {

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
@@ -39,6 +40,7 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDObjectReference;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
@@ -1070,6 +1072,380 @@ public class NonVisualRegressionTest {
                 }
                 collectStructureTags(elem, tags, pattern);
             }
+        }
+    }
+
+    /**
+     * Tests that links inside running footers get proper /Link structure elements
+     * instead of being completely hidden inside pagination artifacts (PDF/UA-1 §7.18).
+     */
+    @Test
+    public void testRunningFooterLinksGetLinkStructureElements() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Running Footer Link Test</title>" +
+            "<meta name='description' content='Test running footer links'/>" +
+            "<style>" +
+            "@page { @bottom-center { content: element(footer); } margin-bottom: 50px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><p>Contact: <a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></p></div>" +
+            "<p>Page content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // Find /Link structure elements in the tree.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertFalse("Should find at least one /Link structure element", linkElements.isEmpty());
+
+            // Verify the /Link element has both an OBJR kid (annotation) and content (MCID).
+            PDStructureElement linkElem = linkElements.get(0);
+            boolean hasObjr = false;
+            boolean hasContent = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    hasContent = true;
+                }
+            }
+            assertTrue("/Link should have an OBJR kid (annotation reference)", hasObjr);
+            assertTrue("/Link should have tagged content (MCID)", hasContent);
+        }
+    }
+
+    private static void collectLinkStructureElements(PDStructureNode node, List<PDStructureElement> result) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                if ("Link".equals(elem.getStructureType())) {
+                    result.add(elem);
+                }
+                collectLinkStructureElements(elem, result);
+            }
+        }
+    }
+
+    /**
+     * Diagnostic test: verifies the link annotation rectangle for a running footer link
+     * is positioned within the bottom margin area of the page (not at y=0 or in the content area).
+     */
+    @Test
+    public void testRunningFooterLinkAnnotationPosition() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Link Position Test</title>" +
+            "<meta name='description' content='Test link position'/>" +
+            "<style>" +
+            "@page { size: 200px 400px; margin: 20px 10px 60px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Example'>Click here</a></div>" +
+            "<p>Body text</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDPage page = doc.getPage(0);
+            List<PDAnnotation> annots = page.getAnnotations();
+            assertFalse("Should have at least one annotation", annots.isEmpty());
+
+            PDAnnotationLink linkAnnot = null;
+            for (PDAnnotation a : annots) {
+                if (a instanceof PDAnnotationLink) {
+                    linkAnnot = (PDAnnotationLink) a;
+                    break;
+                }
+            }
+            assertNotNull("Should find a link annotation", linkAnnot);
+
+            PDRectangle rect = linkAnnot.getRectangle();
+            // Page is 400px = 300pt, bottom margin is 60px = 45pt.
+            // The entire link rect should fit inside the bottom margin band (y=0 to ~45pt).
+            float bottomMarginPt = 45f;
+            assertTrue("Link bottom y=" + rect.getLowerLeftY() + " should be > 0",
+                rect.getLowerLeftY() > 0);
+            assertTrue("Link top y=" + rect.getUpperRightY() + " should be in bottom margin (< " + bottomMarginPt + ")",
+                rect.getUpperRightY() < bottomMarginPt);
+            assertTrue("Link should have positive dimensions",
+                rect.getHeight() > 0 && rect.getWidth() > 0);
+        }
+    }
+
+    /**
+     * Tests that running footer links work correctly across multiple pages.
+     * The /Link structure element should be reused (not duplicated) and each page
+     * should have its own link annotation connected via OBJR.
+     */
+    @Test
+    public void testRunningFooterLinkAcrossMultiplePages() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-page Footer Link Test</title>" +
+            "<meta name='description' content='Test multi-page footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 40px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            ".break { page-break-before: always; }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></div>" +
+            "<p>Page 1</p>" +
+            "<p class='break'>Page 2</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 2 pages", 2, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // There should be exactly one /Link structure element (reused across pages).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should have exactly one /Link element (reused)", 1, linkElements.size());
+
+            // The /Link should have OBJRs for both pages' annotations.
+            PDStructureElement linkElem = linkElements.get(0);
+            int objrCount = 0;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    objrCount++;
+                }
+            }
+            assertEquals("Should have 2 OBJRs (one per page)", 2, objrCount);
+
+            // Both pages should have link annotations.
+            for (int i = 0; i < 2; i++) {
+                List<PDAnnotation> annots = doc.getPage(i).getAnnotations();
+                boolean hasLink = false;
+                for (PDAnnotation a : annots) {
+                    if (a instanceof PDAnnotationLink) {
+                        hasLink = true;
+                        break;
+                    }
+                }
+                assertTrue("Page " + (i + 1) + " should have a link annotation", hasLink);
+            }
+        }
+    }
+
+    /**
+     * Tests that multiple links in a single running footer each get their own
+     * /Link structure element. Exercises the anchor-switching path in
+     * ensureRunningLinkStructure when _runningLinkDomElement changes.
+     */
+    @Test
+    public void testRunningFooterMultipleLinks() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multiple Footer Links Test</title>" +
+            "<meta name='description' content='Test multiple footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'>" +
+            "  <a href='tel:+123' title='Phone'>Phone</a>" +
+            "  <a href='mailto:a@b.c' title='Email'>Email</a>" +
+            "</div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find 2 /Link structure elements", 2, linkElements.size());
+
+            // Each /Link should have both content (MCID) and annotation (OBJR).
+            for (int i = 0; i < linkElements.size(); i++) {
+                boolean hasObjr = false;
+                boolean hasContent = false;
+                for (Object kid : linkElements.get(i).getKids()) {
+                    if (kid instanceof PDObjectReference) {
+                        hasObjr = true;
+                    } else {
+                        hasContent = true;
+                    }
+                }
+                assertTrue("/Link " + (i + 1) + " should have OBJR", hasObjr);
+                assertTrue("/Link " + (i + 1) + " should have content", hasContent);
+            }
+        }
+    }
+
+    /**
+     * Tests that an image inside a link in a running footer gets a proper /Figure
+     * structure element (with alt text) nested under /Link, not a plain GenericContentItem.
+     * Exercises createRunningLinkFigureItem (StructureType.REPLACED path).
+     */
+    @Test
+    public void testRunningFooterImageLinkGetsFigureStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Image Link Footer Test</title>" +
+            "<meta name='description' content='Test image link in footer'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Logo link'>" +
+            "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='Logo' style='width:10px;height:10px;'/> Home</a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Find /Link structure elements.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link", 1, linkElements.size());
+
+            PDStructureElement linkElem = linkElements.get(0);
+            // /Link should have an OBJR kid (annotation reference).
+            boolean hasObjr = false;
+            // /Link should have a /Figure child structure element (not just a generic content item).
+            boolean hasFigureChild = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else if (kid instanceof PDStructureElement) {
+                    PDStructureElement childElem = (PDStructureElement) kid;
+                    if ("Figure".equals(childElem.getStructureType())) {
+                        hasFigureChild = true;
+                        // Figure should have alt text.
+                        assertNotNull("Figure should have alt text",
+                            childElem.getAlternateDescription());
+                        assertFalse("Figure alt text should not be empty",
+                            childElem.getAlternateDescription().isEmpty());
+                    }
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have /Figure child with alt text", hasFigureChild);
+        }
+    }
+
+    /**
+     * Tests that a running footer link with multiple text nodes (e.g. icon + label)
+     * reuses the same /Link structure via the cache (exercises _runningLinkCache hit path).
+     */
+    @Test
+    public void testRunningFooterLinkMultipleSpansReusesStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-span Link Footer Test</title>" +
+            "<meta name='description' content='Test multi-span link'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+123' title='Call'>" +
+            "<span>Icon</span> <span>Call us</span></a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Should still be exactly one /Link (structure reused for both spans).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link (reused)", 1, linkElements.size());
+
+            // The /Link should have multiple content kids (one per text node) plus OBJR.
+            PDStructureElement linkElem = linkElements.get(0);
+            int contentKids = 0;
+            boolean hasObjr = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    contentKids++;
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have multiple content kids (>1)", contentKids > 1);
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -39,6 +39,9 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.Assert;
@@ -1006,6 +1009,67 @@ public class NonVisualRegressionTest {
             assertEquals(doc.getPage(2).getMediaBox().getUpperRightY(), dest2.getTop(), 1.0d);
 
             remove("named-destinations-basic", doc);
+        }
+    }
+
+    /**
+     * Tests that the PDF structure tree follows DOM order, not CSS paint order.
+     * CSS paints backgrounds first, then floats, then inlines - which differs
+     * from the DOM order. The structure tree must follow DOM order per
+     * PDF/UA-1 rule 7.4.2-1.
+     */
+    @Test
+    public void testStructureTreeFollowsDomOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Structure Tree Ordering Test</title>" +
+            "<meta name='description' content='Test structure tree DOM ordering'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First</h1>" +
+            "<h2>Second</h2>" +
+            "<h3>Third</h3>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
+    /**
+     * Recursively collects structure element tags matching the given regex pattern
+     * in document order from the PDF structure tree.
+     */
+    private static void collectStructureTags(PDStructureNode node, List<String> tags, String pattern) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                String tag = elem.getStructureType();
+                if (tag != null && tag.matches(pattern)) {
+                    tags.add(tag);
+                }
+                collectStructureTags(elem, tags, pattern);
+            }
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -1449,6 +1449,55 @@ public class NonVisualRegressionTest {
         }
     }
 
+    /**
+     * Tests that headings split across page breaks preserve correct reading order
+     * in the structure tree. Page breaks create new branches in the structure tree,
+     * but the heading order must remain H1 → H2 → H3 regardless of page boundaries.
+     */
+    @Test
+    public void testHeadingsAcrossPageBreaksPreserveOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Headings Across Pages Test</title>" +
+            "<meta name='description' content='Test heading order across page breaks'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First heading</h1>" +
+            "<p>Some content on page one.</p>" +
+            "<h2 style='page-break-before: always;'>Second heading on page two</h2>" +
+            "<p>Content on page two.</p>" +
+            "<h3 style='page-break-before: always;'>Third heading on page three</h3>" +
+            "<p>Content on page three.</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 3 pages", 3, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
     // TODO:
     // + More form controls.
     // + Custom meta info.

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
@@ -39,6 +40,7 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDObjectReference;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
@@ -1088,6 +1090,380 @@ public class NonVisualRegressionTest {
                 }
                 collectStructureTags(elem, tags, pattern);
             }
+        }
+    }
+
+    /**
+     * Tests that links inside running footers get proper /Link structure elements
+     * instead of being completely hidden inside pagination artifacts (PDF/UA-1 §7.18).
+     */
+    @Test
+    public void testRunningFooterLinksGetLinkStructureElements() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Running Footer Link Test</title>" +
+            "<meta name='description' content='Test running footer links'/>" +
+            "<style>" +
+            "@page { @bottom-center { content: element(footer); } margin-bottom: 50px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><p>Contact: <a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></p></div>" +
+            "<p>Page content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // Find /Link structure elements in the tree.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertFalse("Should find at least one /Link structure element", linkElements.isEmpty());
+
+            // Verify the /Link element has both an OBJR kid (annotation) and content (MCID).
+            PDStructureElement linkElem = linkElements.get(0);
+            boolean hasObjr = false;
+            boolean hasContent = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    hasContent = true;
+                }
+            }
+            assertTrue("/Link should have an OBJR kid (annotation reference)", hasObjr);
+            assertTrue("/Link should have tagged content (MCID)", hasContent);
+        }
+    }
+
+    private static void collectLinkStructureElements(PDStructureNode node, List<PDStructureElement> result) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                if ("Link".equals(elem.getStructureType())) {
+                    result.add(elem);
+                }
+                collectLinkStructureElements(elem, result);
+            }
+        }
+    }
+
+    /**
+     * Diagnostic test: verifies the link annotation rectangle for a running footer link
+     * is positioned within the bottom margin area of the page (not at y=0 or in the content area).
+     */
+    @Test
+    public void testRunningFooterLinkAnnotationPosition() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Link Position Test</title>" +
+            "<meta name='description' content='Test link position'/>" +
+            "<style>" +
+            "@page { size: 200px 400px; margin: 20px 10px 60px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Example'>Click here</a></div>" +
+            "<p>Body text</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDPage page = doc.getPage(0);
+            List<PDAnnotation> annots = page.getAnnotations();
+            assertFalse("Should have at least one annotation", annots.isEmpty());
+
+            PDAnnotationLink linkAnnot = null;
+            for (PDAnnotation a : annots) {
+                if (a instanceof PDAnnotationLink) {
+                    linkAnnot = (PDAnnotationLink) a;
+                    break;
+                }
+            }
+            assertNotNull("Should find a link annotation", linkAnnot);
+
+            PDRectangle rect = linkAnnot.getRectangle();
+            // Page is 400px = 300pt, bottom margin is 60px = 45pt.
+            // The entire link rect should fit inside the bottom margin band (y=0 to ~45pt).
+            float bottomMarginPt = 45f;
+            assertTrue("Link bottom y=" + rect.getLowerLeftY() + " should be > 0",
+                rect.getLowerLeftY() > 0);
+            assertTrue("Link top y=" + rect.getUpperRightY() + " should be in bottom margin (< " + bottomMarginPt + ")",
+                rect.getUpperRightY() < bottomMarginPt);
+            assertTrue("Link should have positive dimensions",
+                rect.getHeight() > 0 && rect.getWidth() > 0);
+        }
+    }
+
+    /**
+     * Tests that running footer links work correctly across multiple pages.
+     * The /Link structure element should be reused (not duplicated) and each page
+     * should have its own link annotation connected via OBJR.
+     */
+    @Test
+    public void testRunningFooterLinkAcrossMultiplePages() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-page Footer Link Test</title>" +
+            "<meta name='description' content='Test multi-page footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 40px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            ".break { page-break-before: always; }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></div>" +
+            "<p>Page 1</p>" +
+            "<p class='break'>Page 2</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 2 pages", 2, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // There should be exactly one /Link structure element (reused across pages).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should have exactly one /Link element (reused)", 1, linkElements.size());
+
+            // The /Link should have OBJRs for both pages' annotations.
+            PDStructureElement linkElem = linkElements.get(0);
+            int objrCount = 0;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    objrCount++;
+                }
+            }
+            assertEquals("Should have 2 OBJRs (one per page)", 2, objrCount);
+
+            // Both pages should have link annotations.
+            for (int i = 0; i < 2; i++) {
+                List<PDAnnotation> annots = doc.getPage(i).getAnnotations();
+                boolean hasLink = false;
+                for (PDAnnotation a : annots) {
+                    if (a instanceof PDAnnotationLink) {
+                        hasLink = true;
+                        break;
+                    }
+                }
+                assertTrue("Page " + (i + 1) + " should have a link annotation", hasLink);
+            }
+        }
+    }
+
+    /**
+     * Tests that multiple links in a single running footer each get their own
+     * /Link structure element. Exercises the anchor-switching path in
+     * ensureRunningLinkStructure when _runningLinkDomElement changes.
+     */
+    @Test
+    public void testRunningFooterMultipleLinks() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multiple Footer Links Test</title>" +
+            "<meta name='description' content='Test multiple footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'>" +
+            "  <a href='tel:+123' title='Phone'>Phone</a>" +
+            "  <a href='mailto:a@b.c' title='Email'>Email</a>" +
+            "</div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find 2 /Link structure elements", 2, linkElements.size());
+
+            // Each /Link should have both content (MCID) and annotation (OBJR).
+            for (int i = 0; i < linkElements.size(); i++) {
+                boolean hasObjr = false;
+                boolean hasContent = false;
+                for (Object kid : linkElements.get(i).getKids()) {
+                    if (kid instanceof PDObjectReference) {
+                        hasObjr = true;
+                    } else {
+                        hasContent = true;
+                    }
+                }
+                assertTrue("/Link " + (i + 1) + " should have OBJR", hasObjr);
+                assertTrue("/Link " + (i + 1) + " should have content", hasContent);
+            }
+        }
+    }
+
+    /**
+     * Tests that an image inside a link in a running footer gets a proper /Figure
+     * structure element (with alt text) nested under /Link, not a plain GenericContentItem.
+     * Exercises createRunningLinkFigureItem (StructureType.REPLACED path).
+     */
+    @Test
+    public void testRunningFooterImageLinkGetsFigureStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Image Link Footer Test</title>" +
+            "<meta name='description' content='Test image link in footer'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Logo link'>" +
+            "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='Logo' style='width:10px;height:10px;'/> Home</a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Find /Link structure elements.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link", 1, linkElements.size());
+
+            PDStructureElement linkElem = linkElements.get(0);
+            // /Link should have an OBJR kid (annotation reference).
+            boolean hasObjr = false;
+            // /Link should have a /Figure child structure element (not just a generic content item).
+            boolean hasFigureChild = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else if (kid instanceof PDStructureElement) {
+                    PDStructureElement childElem = (PDStructureElement) kid;
+                    if ("Figure".equals(childElem.getStructureType())) {
+                        hasFigureChild = true;
+                        // Figure should have alt text.
+                        assertNotNull("Figure should have alt text",
+                            childElem.getAlternateDescription());
+                        assertFalse("Figure alt text should not be empty",
+                            childElem.getAlternateDescription().isEmpty());
+                    }
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have /Figure child with alt text", hasFigureChild);
+        }
+    }
+
+    /**
+     * Tests that a running footer link with multiple text nodes (e.g. icon + label)
+     * reuses the same /Link structure via the cache (exercises _runningLinkCache hit path).
+     */
+    @Test
+    public void testRunningFooterLinkMultipleSpansReusesStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-span Link Footer Test</title>" +
+            "<meta name='description' content='Test multi-span link'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+123' title='Call'>" +
+            "<span>Icon</span> <span>Call us</span></a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Should still be exactly one /Link (structure reused for both spans).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link (reused)", 1, linkElements.size());
+
+            // The /Link should have multiple content kids (one per text node) plus OBJR.
+            PDStructureElement linkElem = linkElements.get(0);
+            int contentKids = 0;
+            boolean hasObjr = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    contentKids++;
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have multiple content kids (>1)", contentKids > 1);
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -39,6 +39,9 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.Assert;
@@ -1024,6 +1027,67 @@ public class NonVisualRegressionTest {
             assertEquals(doc.getPage(2).getMediaBox().getUpperRightY(), dest2.getTop(), 1.0d);
 
             remove("named-destinations-basic", doc);
+        }
+    }
+
+    /**
+     * Tests that the PDF structure tree follows DOM order, not CSS paint order.
+     * CSS paints backgrounds first, then floats, then inlines - which differs
+     * from the DOM order. The structure tree must follow DOM order per
+     * PDF/UA-1 rule 7.4.2-1.
+     */
+    @Test
+    public void testStructureTreeFollowsDomOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Structure Tree Ordering Test</title>" +
+            "<meta name='description' content='Test structure tree DOM ordering'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First</h1>" +
+            "<h2>Second</h2>" +
+            "<h3>Third</h3>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
+    /**
+     * Recursively collects structure element tags matching the given regex pattern
+     * in document order from the PDF structure tree.
+     */
+    private static void collectStructureTags(PDStructureNode node, List<String> tags, String pattern) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                String tag = elem.getStructureType();
+                if (tag != null && tag.matches(pattern)) {
+                    tags.add(tag);
+                }
+                collectStructureTags(elem, tags, pattern);
+            }
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -1467,6 +1467,55 @@ public class NonVisualRegressionTest {
         }
     }
 
+    /**
+     * Tests that headings split across page breaks preserve correct reading order
+     * in the structure tree. Page breaks create new branches in the structure tree,
+     * but the heading order must remain H1 → H2 → H3 regardless of page boundaries.
+     */
+    @Test
+    public void testHeadingsAcrossPageBreaksPreserveOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Headings Across Pages Test</title>" +
+            "<meta name='description' content='Test heading order across page breaks'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First heading</h1>" +
+            "<p>Some content on page one.</p>" +
+            "<h2 style='page-break-before: always;'>Second heading on page two</h2>" +
+            "<p>Content on page two.</p>" +
+            "<h3 style='page-break-before: always;'>Third heading on page three</h3>" +
+            "<p>Content on page three.</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 3 pages", 3, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
     // TODO:
     // + More form controls.
     // + Custom meta info.

--- a/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
+++ b/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
@@ -119,4 +119,16 @@ public class PdfUaTester {
     public void testStructureWithRunningFooterLinks() throws Exception {
         assertTrue(run("pdfua-structure"));
     }
+
+    /**
+     * Verifies that empty img elements (no src or broken src) do not cause
+     * NPE in FigureStructualElement.finish() when building the PDF/UA
+     * structure tree. The FigureContentItem may be null if no content was
+     * painted for the replaced element.
+     */
+    @Test
+    public void testEmptyFigureDoesNotCauseNpe() throws Exception {
+        // Should not throw NPE — compliance is not required, just no crash.
+        run("pdfua-figure-empty");
+    }
 }

--- a/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
+++ b/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
@@ -1,0 +1,122 @@
+package com.openhtmltopdf.pdfa.testing;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.apache.pdfbox.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.verapdf.pdfa.Foundries;
+import org.verapdf.pdfa.PDFAParser;
+import org.verapdf.pdfa.PDFAValidator;
+import org.verapdf.pdfa.VeraGreenfieldFoundryProvider;
+import org.verapdf.pdfa.VeraPDFFoundry;
+import org.verapdf.pdfa.flavours.PDFAFlavour;
+import org.verapdf.pdfa.results.TestAssertion;
+import org.verapdf.pdfa.results.TestAssertion.Status;
+import org.verapdf.pdfa.results.ValidationResult;
+
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceControlPriority;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.util.XRLog;
+
+/**
+ * PDF/UA-1 validation tests using veraPDF.
+ * Validates structure tree ordering (rule 7.4.2-1) and link structure (rules 7.18.x).
+ */
+public class PdfUaTester {
+    @BeforeClass
+    public static void initialize() {
+        VeraGreenfieldFoundryProvider.initialise();
+        XRLog.listRegisteredLoggers().forEach(log -> XRLog.setLevel(log, Level.WARNING));
+    }
+
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(keyExtractor.apply(t));
+    }
+
+    private boolean run(String resource) throws Exception {
+        byte[] htmlBytes;
+        try (InputStream is = PdfUaTester.class.getResourceAsStream("/html/" + resource + ".html")) {
+            if (is == null) {
+                throw new IllegalStateException("HTML resource /html/" + resource + ".html not found");
+            }
+            htmlBytes = IOUtils.toByteArray(is);
+        }
+        String html = new String(htmlBytes, StandardCharsets.UTF_8);
+
+        Files.createDirectories(Paths.get("target/test/artefacts/"));
+        if (!Files.exists(Paths.get("target/test/artefacts/Karla-Bold.ttf"))) {
+            try (InputStream in = PdfUaTester.class.getResourceAsStream("/fonts/Karla-Bold.ttf")) {
+                if (in == null) {
+                    throw new IllegalStateException("Font resource /fonts/Karla-Bold.ttf not found");
+                }
+                Files.write(Paths.get("target/test/artefacts/Karla-Bold.ttf"), IOUtils.toByteArray(in));
+            }
+        }
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.usePdfVersion(1.7f);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(new File("target/test/artefacts/Karla-Bold.ttf"), "TestFont");
+        builder.withHtmlContent(html, PdfUaTester.class.getResource("/html/").toString());
+        builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_AFTER_RESOLVING_URI);
+        builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_BEFORE_RESOLVING_URI);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        builder.toStream(baos);
+        builder.run();
+        byte[] pdfBytes = baos.toByteArray();
+
+        Files.createDirectories(Paths.get("target/test/pdf/"));
+        Files.write(Paths.get("target/test/pdf/" + resource + "--PDFUA_1.pdf"), pdfBytes);
+
+        PDFAFlavour flavour = PDFAFlavour.PDFUA_1;
+
+        try (VeraPDFFoundry foundry = Foundries.defaultInstance();
+             InputStream is = new ByteArrayInputStream(pdfBytes);
+             PDFAValidator validator = foundry.createValidator(flavour, true);
+             PDFAParser parser = foundry.createParser(is, flavour)) {
+
+            ValidationResult result = validator.validate(parser);
+
+            List<TestAssertion> asserts = result.getTestAssertions().stream()
+                    .filter(ta -> ta.getStatus() == Status.FAILED)
+                    .filter(distinctByKey(TestAssertion::getRuleId))
+                    .collect(Collectors.toList());
+
+            String errs = asserts.stream()
+                    .map(ta -> String.format("%s\n    %s", ta.getMessage().replaceAll("\\s+", " "), ta.getLocation().getContext()))
+                    .collect(Collectors.joining("\n    ", "[\n    ", "\n]"));
+
+            System.err.format("\nDISTINCT ERRORS(%s--PDFUA_1) (%d): %s\n", resource, asserts.size(), errs);
+
+            return asserts.isEmpty() && result.isCompliant();
+        }
+    }
+
+    @Test
+    public void testAllInOnePdfUa1() throws Exception {
+        assertTrue(run("all-in-one"));
+    }
+
+    @Test
+    public void testStructureWithRunningFooterLinks() throws Exception {
+        assertTrue(run("pdfua-structure"));
+    }
+}

--- a/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-figure-empty.html
+++ b/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-figure-empty.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="EN-US">
+<head>
+  <title>PDF/UA Figure Empty Content Test</title>
+  <meta name="subject" content="PDF/UA figure with no content"/>
+  <meta name="author" content="openhtmltopdf.com team"/>
+  <meta name="description" content="Tests that empty img elements do not cause NPE in structure tree"/>
+
+  <bookmarks>
+    <bookmark name="Figures" href="#figures"/>
+  </bookmarks>
+
+  <style>
+  @page {
+    margin: 30px 20px 60px 20px;
+  }
+  body {
+    margin: 0;
+    font-family: 'TestFont';
+    font-size: 15px;
+  }
+  </style>
+</head>
+<body>
+  <h1 id="figures">Figure test</h1>
+  <p>Paragraph before empty images.</p>
+
+  <!-- Empty img with no src - should not cause NPE in FigureStructualElement.finish() -->
+  <img alt="Empty image placeholder"/>
+
+  <!-- Broken src that will not resolve -->
+  <img src="" alt="Empty src image"/>
+
+  <p>Paragraph after empty images.</p>
+</body>
+</html>

--- a/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-structure.html
+++ b/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-structure.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="EN-US">
+<head>
+  <title>PDF/UA Structure Test</title>
+  <meta name="subject" content="PDF/UA structure validation"/>
+  <meta name="author" content="openhtmltopdf.com team"/>
+  <meta name="description" content="Tests heading order and link structure for PDF/UA-1"/>
+
+  <bookmarks>
+    <bookmark name="Main heading" href="#main"/>
+    <bookmark name="Section" href="#section"/>
+    <bookmark name="Subsection" href="#subsection"/>
+    <bookmark name="Links" href="#links"/>
+  </bookmarks>
+
+  <style>
+  @page {
+    margin: 30px 20px 60px 20px;
+
+    @bottom-center {
+      font-family: 'TestFont';
+      font-size: 12px;
+      content: element(footer);
+    }
+  }
+  body {
+    margin: 0;
+    font-family: 'TestFont';
+    font-size: 15px;
+  }
+  #footer {
+    position: running(footer);
+  }
+  </style>
+</head>
+<body>
+  <div id="footer">
+    <p>Contact: <a href="https://openhtmltopdf.com" title="Visit homepage">openhtmltopdf.com</a></p>
+  </div>
+
+  <h1 id="main">Main heading</h1>
+  <p>First paragraph with enough text to fill some space on the page.</p>
+
+  <h2 id="section">Section heading</h2>
+  <p>Second paragraph with content under the section heading.</p>
+
+  <h3 id="subsection">Subsection heading</h3>
+  <p>Third paragraph with content under the subsection heading.</p>
+
+  <h2 id="links">Links section</h2>
+  <p>This is a link to the <a title="The openhtmltopdf.com homepage" href="https://openhtmltopdf.com">homepage</a>.</p>
+  <p>This is an internal link to the <a title="Go to top" href="#main">top</a> of the document.</p>
+</body>
+</html>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -766,7 +766,9 @@ public class PdfBoxAccessibilityHelper {
 
             child.parentElem.appendKid(child.elem);
 
-            finishTreeItem(child.content, child);
+            if (child.content != null) {
+                finishTreeItem(child.content, child);
+            }
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -3,6 +3,8 @@ package com.openhtmltopdf.pdfboxout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,6 +28,7 @@ import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDMarkedConte
 import org.apache.pdfbox.pdmodel.documentinterchange.taggedpdf.StandardStructureTypes;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
@@ -839,6 +842,7 @@ public class PdfBoxAccessibilityHelper {
             root.appendKid(rootElem);
 
             _root.elem = rootElem;
+            sortChildrenByDomOrder(_root);
             finishTreeItems(_root.children, _root);
 
             _od.getWriter().getDocumentCatalog().setStructureTreeRoot(root);
@@ -894,6 +898,101 @@ public class PdfBoxAccessibilityHelper {
         } else {
             return StandardStructureTypes.SPAN;
         }
+    }
+
+    /**
+     * Recursively sorts children of GenericStructualElement nodes by DOM document order.
+     * This fixes PDF/UA-1 rule 7.4.2-1 where structure tree order must follow logical
+     * reading order (DOM order), not CSS paint order.
+     *
+     * Table and list structures are excluded as they have their own semantic ordering.
+     */
+    private static void sortChildrenByDomOrder(AbstractStructualElement element) {
+        if (element instanceof GenericStructualElement) {
+            GenericStructualElement generic = (GenericStructualElement) element;
+            sortByDomOrder(generic.children);
+            for (AbstractTreeItem child : generic.children) {
+                if (child instanceof AbstractStructualElement) {
+                    sortChildrenByDomOrder((AbstractStructualElement) child);
+                }
+            }
+        } else if (element instanceof ListStructualElement) {
+            ListStructualElement list = (ListStructualElement) element;
+            sortByDomOrder(list.listItems);
+            for (ListItemStructualElement item : list.listItems) {
+                sortChildrenByDomOrder(item);
+            }
+        } else if (element instanceof ListItemStructualElement) {
+            ListItemStructualElement item = (ListItemStructualElement) element;
+            sortChildrenByDomOrder(item.body);
+        } else if (element instanceof TableStructualElement) {
+            TableStructualElement table = (TableStructualElement) element;
+            sortByDomOrder(table.tbodies);
+            sortChildrenByDomOrder(table.thead);
+            for (TableBodyStructualElement tbody : table.tbodies) {
+                sortChildrenByDomOrder(tbody);
+            }
+            sortChildrenByDomOrder(table.tfoot);
+        }
+    }
+
+    /**
+     * Sorts items that have a DOM node by document order, leaving items
+     * without a DOM node (anonymous boxes, text runs) in their original
+     * positions. This avoids Comparator transitivity issues that arise
+     * when mixing DOM-based and index-based ordering in a single sort.
+     */
+    private static <T extends AbstractTreeItem> void sortByDomOrder(List<T> children) {
+        if (children.size() < 2) {
+            return;
+        }
+
+        // Collect anchored items (those with a DOM node) and their positions.
+        List<Integer> anchoredIndices = new ArrayList<>();
+        List<T> anchoredItems = new ArrayList<>();
+
+        for (int i = 0; i < children.size(); i++) {
+            if (getDomNode(children.get(i)) != null) {
+                anchoredIndices.add(i);
+                anchoredItems.add(children.get(i));
+            }
+        }
+
+        if (anchoredItems.size() < 2) {
+            return;
+        }
+
+        // Sort anchored items by DOM document order.
+        Collections.sort(anchoredItems, new Comparator<T>() {
+            @Override
+            public int compare(T a, T b) {
+                Node nodeA = getDomNode(a);
+                Node nodeB = getDomNode(b);
+
+                short pos = nodeA.compareDocumentPosition(nodeB);
+                if ((pos & Node.DOCUMENT_POSITION_FOLLOWING) != 0) {
+                    return -1;
+                } else if ((pos & Node.DOCUMENT_POSITION_PRECEDING) != 0) {
+                    return 1;
+                }
+                return 0;
+            }
+        });
+
+        // Write sorted anchored items back into their original slots.
+        for (int i = 0; i < anchoredIndices.size(); i++) {
+            children.set(anchoredIndices.get(i), anchoredItems.get(i));
+        }
+    }
+
+    private static Node getDomNode(AbstractTreeItem item) {
+        if (item instanceof AbstractStructualElement) {
+            Box box = ((AbstractStructualElement) item).box;
+            if (box != null && box.getElement() != null) {
+                return box.getElement();
+            }
+        }
+        return null;
     }
 
     private static void finishTreeItems(List<? extends AbstractTreeItem> children, AbstractStructualElement parent) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -65,6 +65,21 @@ public class PdfBoxAccessibilityHelper {
 
     private int _runningLevel;
 
+    /**
+     * When non-null, we are inside a running element that contains a link.
+     * Text content that is a DOM descendant of this link will get proper
+     * /Link structure elements instead of being marked as artifact.
+     */
+    private AnchorStuctualElement _runningLinkStructure;
+    private org.w3c.dom.Element _runningLinkDomElement;
+
+    /**
+     * Maps anchor DOM elements in running content to their /Link structure elements.
+     * Running content box objects are re-created per page, so we track by DOM element
+     * to reuse the same structure element across pages.
+     */
+    private final Map<org.w3c.dom.Element, AnchorStuctualElement> _runningLinkCache = new HashMap<>();
+
     private static Map<String, Supplier<AbstractStructualElement>> createTagSuppliers() {
         Map<String, Supplier<AbstractStructualElement>> suppliers = new HashMap<>();
 
@@ -995,6 +1010,116 @@ public class PdfBoxAccessibilityHelper {
         return null;
     }
 
+    /**
+     * Walks up the DOM from the box's element looking for an {@code <a>} ancestor.
+     * Returns the anchor element or null if not found.
+     */
+    private static org.w3c.dom.Element findAnchorAncestor(Box box) {
+        if (box == null || box.getElement() == null) {
+            return null;
+        }
+        org.w3c.dom.Node node = box.getElement();
+        while (node != null) {
+            if (node instanceof org.w3c.dom.Element && "a".equals(((org.w3c.dom.Element) node).getTagName())) {
+                return (org.w3c.dom.Element) node;
+            }
+            node = node.getParentNode();
+        }
+        return null;
+    }
+
+    /**
+     * Ensures a /Link structure element exists for a running content anchor.
+     * On the first page, creates the structure element and attaches it to the root.
+     * On subsequent pages, reuses the existing one.
+     */
+    private void ensureRunningLinkStructure(Box box, org.w3c.dom.Element anchorElem) {
+        if (_runningLinkStructure != null && _runningLinkDomElement == anchorElem) {
+            return; // Already set up for this anchor on this page.
+        }
+
+        // Running content box objects are re-created per page, so we track by DOM element.
+        AnchorStuctualElement cached = _runningLinkCache.get(anchorElem);
+        if (cached != null) {
+            _runningLinkStructure = cached;
+        } else {
+            AnchorStuctualElement struct = new AnchorStuctualElement();
+            struct.page = _page;
+            struct.box = box;
+            struct.setPdfVersion(_od.getWriter().getVersion());
+            _root.addChild(struct);
+            struct.parent = _root;
+            _runningLinkCache.put(anchorElem, struct);
+            _runningLinkStructure = struct;
+        }
+        _runningLinkDomElement = anchorElem;
+
+        // Set the accessibility object on the current page's anchor box so that
+        // addLink() can find the /Link structure element via getStructualElementForBox().
+        // Running content re-creates box objects per page, so this must be done every time.
+        Box anchorBox = findAnchorBox(box, anchorElem);
+        if (anchorBox != null) {
+            anchorBox.setAccessiblityObject(_runningLinkStructure);
+        }
+    }
+
+    /**
+     * Walks up from a box to find the box whose element matches the anchor element.
+     */
+    private static Box findAnchorBox(Box box, org.w3c.dom.Element anchorElem) {
+        Box current = box;
+        while (current != null) {
+            if (current.getElement() == anchorElem) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    private GenericContentItem createRunningLinkContentItem() {
+        GenericContentItem current = new GenericContentItem();
+        _runningLinkStructure.addChild(current);
+        current.parent = _runningLinkStructure;
+        current.mcid = _nextMcid;
+        current.dict = createMarkedContentDictionary();
+        current.page = _page;
+        _pageItems._contentItems.add(current);
+        return current;
+    }
+
+    /**
+     * Creates a /Figure structure element under the running /Link for REPLACED (image) content.
+     * This preserves alt text and BBox semantics that would be lost with a plain GenericContentItem.
+     */
+    private FigureContentItem createRunningLinkFigureItem(Box box) {
+        FigureStructualElement figure = new FigureStructualElement();
+        figure.page = _page;
+        figure.box = box;
+
+        Rectangle2D rect = PdfBoxFastLinkManager.createTargetArea(
+                _ctx, box, _pageHeight, _transform, _ctx.getPage(), _od);
+        figure.boundingBox = new PDRectangle(
+                (float) rect.getMinX(),
+                (float) rect.getMinY(),
+                (float) rect.getWidth(),
+                (float) rect.getHeight());
+
+        _runningLinkStructure.addChild(figure);
+        figure.parent = _runningLinkStructure;
+
+        FigureContentItem content = new FigureContentItem();
+        figure.addChild(content);
+        content.parent = figure;
+        content.mcid = _nextMcid;
+        content.dict = createMarkedContentDictionary();
+        content.page = _page;
+        figure.content = content;
+
+        _pageItems._contentItems.add(content);
+        return content;
+    }
+
     private static void finishTreeItems(List<? extends AbstractTreeItem> children, AbstractStructualElement parent) {
         for (AbstractTreeItem child : children) {
             child.finish(parent);
@@ -1182,7 +1307,7 @@ public class PdfBoxAccessibilityHelper {
         return dict;
     }
 
-    private COSDictionary createPaginationArtifact(StructureType type, Box box) {
+    private COSDictionary createPaginationArtifact() {
         COSDictionary dict = new COSDictionary();
         dict.setItem(COSName.TYPE, COSName.getPDFName("Pagination"));
         return dict;
@@ -1196,6 +1321,7 @@ public class PdfBoxAccessibilityHelper {
     private static final Token INSIDE_RUNNING = new Token();
     private static final Token STARTING_RUNNING = new Token();
     private static final Token NESTED_RUNNING = new Token();
+    private static final Token RUNNING_LINK_TEXT = new Token();
 
     public Token startStructure(StructureType type, Box box) {
             // Check for items that appear on every page (fixed, running, page margins).
@@ -1204,7 +1330,7 @@ public class PdfBoxAccessibilityHelper {
                 // nested fixed elements).
                 if (_runningLevel == 0) {
                     _runningLevel++;
-                    COSDictionary run = createPaginationArtifact(type, box);
+                    COSDictionary run = createPaginationArtifact();
                     _cs.beginMarkedContent(COSName.ARTIFACT, run);
                     return STARTING_RUNNING;
                 }
@@ -1213,6 +1339,31 @@ public class PdfBoxAccessibilityHelper {
                 return NESTED_RUNNING;
             } else if (_runningLevel > 0) {
                 // We are in a running artifact.
+                // Detect content inside anchor elements to create /Link structure (PDF/UA-1 §7.18).
+                // Note: SimplePainter (used for running content) doesn't emit INLINE structure
+                // calls, so we detect anchors at the TEXT/REPLACED level via DOM ancestry.
+                if (type == StructureType.TEXT || type == StructureType.REPLACED) {
+                    org.w3c.dom.Element anchorElem = findAnchorAncestor(box);
+                    if (anchorElem != null) {
+                        ensureRunningLinkStructure(box, anchorElem);
+                        // Temporarily close the artifact BMC.
+                        _cs.endMarkedContent();
+                        // Create content item attached to the /Link structure element.
+                        GenericContentItem current;
+                        String tag;
+                        if (type == StructureType.REPLACED) {
+                            // Use FigureStructualElement to preserve alt text and BBox.
+                            current = createRunningLinkFigureItem(box);
+                            tag = StandardStructureTypes.Figure;
+                        } else {
+                            current = createRunningLinkContentItem();
+                            tag = StandardStructureTypes.SPAN;
+                        }
+                        _cs.beginMarkedContent(COSName.getPDFName(tag), current.dict);
+                        return RUNNING_LINK_TEXT;
+                    }
+                }
+
                 return INSIDE_RUNNING;
             }
 
@@ -1297,7 +1448,15 @@ public class PdfBoxAccessibilityHelper {
             _runningLevel--;
         } else if (value == STARTING_RUNNING) {
             _runningLevel--;
+            _runningLinkStructure = null;
+            _runningLinkDomElement = null;
             _cs.endMarkedContent();
+        } else if (value == RUNNING_LINK_TEXT) {
+            // Close the Span marked content for the link text.
+            _cs.endMarkedContent();
+            // Re-open the pagination artifact BMC.
+            COSDictionary dict = createPaginationArtifact();
+            _cs.beginMarkedContent(COSName.ARTIFACT, dict);
         }
     }
 
@@ -1310,6 +1469,8 @@ public class PdfBoxAccessibilityHelper {
         this._transform = transform;
         this._pageItems = new PageItems();
         this._pageItemsMap.put(page, this._pageItems);
+        this._runningLinkStructure = null;
+        this._runningLinkDomElement = null;
     }
 
     public void endPage() {
@@ -1323,6 +1484,20 @@ public class PdfBoxAccessibilityHelper {
 
     public void addLink(Box anchor, Box target, PDAnnotation pdAnnotation, PDPage page) {
         PDStructureElement struct = getStructualElementForBox(anchor);
+
+        // For running content links, the anchor box may not have its accessibility object set
+        // (e.g. image-only links where the <a> box is in a different parent chain than the <img> box).
+        // Fall back to the running link cache using the DOM element.
+        if (struct == null && anchor.getElement() != null) {
+            org.w3c.dom.Element anchorElem = findAnchorAncestor(anchor);
+            if (anchorElem != null) {
+                AnchorStuctualElement cached = _runningLinkCache.get(anchorElem);
+                if (cached != null) {
+                    struct = cached.elem;
+                }
+            }
+        }
+
         if (struct != null) {
             // We have to append the link annotationobject reference as a kid of its associated structure element.
             PDObjectReference ref = new PDObjectReference();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -248,6 +248,7 @@ public class PdfBoxFastLinkManager {
 
                 PDAnnotationLink annot = new PDAnnotationLink();
                 annot.setAction(action);
+                setLinkContents(annot, elem);
 
                 AnnotationContainer annotContainer = new AnnotationContainer.PDAnnotationLinkContainer(annot);
 
@@ -267,6 +268,7 @@ public class PdfBoxFastLinkManager {
 
                 PDAnnotationLink annot = new PDAnnotationLink();
                 annot.setAction(uriAct);
+                setLinkContents(annot, elem);
 
                 annotContainer = new AnnotationContainer.PDAnnotationLinkContainer(annot);
             } else {
@@ -543,6 +545,23 @@ public class PdfBoxFastLinkManager {
             }
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("processLink", e);
+        }
+    }
+
+    /**
+     * Sets the Contents key on a link annotation for PDF/UA-1 compliance
+     * (ISO 14289-1, 14.9.3). Uses the title attribute if available,
+     * otherwise falls back to the text content of the element.
+     */
+    private static void setLinkContents(PDAnnotationLink annot, Element elem) {
+        String title = elem.getAttribute("title");
+        if (title != null && !title.isEmpty()) {
+            annot.setContents(title);
+        } else {
+            String text = elem.getTextContent();
+            if (text != null && !text.isEmpty()) {
+                annot.setContents(text.trim());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes four PDF/UA-1 (ISO 14289-1) accessibility violations discovered during veraPDF validation. All changes are backward-compatible and only affect PDF output when `usePdfUaAccessibility(true)` is enabled.

### 1. Structure tree DOM ordering (rule 7.4.2-1)

The PDF structure tree was built in CSS paint order (floats first, then normal flow) instead of DOM document order, violating the logical reading order requirement.

**Fix:** Added `sortChildrenByDomOrder()` in `PdfBoxAccessibilityHelper` that recursively reorders structure tree children using `Node.compareDocumentPosition()` before the tree is finalized. Anonymous boxes and text runs stay in place to preserve inline content ordering.

### 2. Link structure in running headers/footers (rules 7.18.1-2, 7.18.5-1, 7.18.5-2)

Links inside running headers/footers (`position: running()`) were painted entirely as pagination artifacts. Link annotations existed in the PDF but had no corresponding `/Link` structure elements.

**Root cause:** `SimplePainter` (used for running content) does not participate in the structure tree.

**Fix:** Implemented a hybrid artifact/structure approach — when painting running content and an anchor element is detected, temporarily close the artifact BMC, emit MCID-tagged content under a `/Link` structure element, then reopen the artifact BMC. A DOM-element-based cache ensures the `/Link` structure is reused across pages. Also added `startStructure(REPLACED)` in `SimplePainter` for replaced elements (images).

### 3. Link annotation Contents key (ISO 32000-1:2008, §14.9.3)

Link annotations were missing the `Contents` key (alternate description) required for PDF/UA-1 compliance.

**Fix:** Added `setLinkContents()` in `PdfBoxFastLinkManager` that sets the alternate description from the `title` attribute, with fallback to element text content.

### 4. NPE on empty figure elements

`FigureStructualElement.finish()` called `finishTreeItem(child.content, child)` unconditionally, but `content` can be `null` when a replaced element (e.g. empty `<img>` with no src) has no associated `FigureContentItem`. This caused a `NullPointerException` during PDF/UA structure tree building.

**Fix:** Added null-check before `finishTreeItem()` call.

## Files changed

| File | Change |
|------|--------|
| `PdfBoxAccessibilityHelper.java` | DOM order sorting + running footer link structure + null-check for FigureContentItem |
| `SimplePainter.java` | `startStructure(REPLACED)` for replaced elements |
| `PdfBoxFastLinkManager.java` | `setLinkContents()` for link annotation alt text |
| `NonVisualRegressionTest.java` | 8 new tests |
| `PdfUaTester.java` | 3 veraPDF PDF/UA-1 validation tests (including empty figure NPE test) |
| `pdfua-structure.html` (new) | Test HTML for veraPDF validation |
| `pdfua-figure-empty.html` (new) | Test HTML for empty img elements |

## PDF/UA-1 rules addressed

| Rule | Description |
|------|-------------|
| 7.4.2-1 | Structure tree shall follow logical reading order |
| 7.18.1-2 | Link annotations shall be nested in `/Link` structure elements |
| 7.18.5-1 | `/Link` shall contain OBJR (annotation object reference) |
| 7.18.5-2 | `/Link` shall include tagged content identifying the link |
| §14.9.3 | Link annotations shall have alternate description (Contents key) |

## Test plan

- [x] All existing tests pass (no regressions)
- [x] 8 new structure tree tests in `NonVisualRegressionTest`
- [x] 3 new veraPDF PDF/UA-1 full-profile validation tests in `PdfUaTester`
- [x] Validated with veraPDF 1.18.8 (already in `openhtmltopdf-pdfa-testing` dependencies)
- [x] Bulk-validated 112 APPROVED PDF templates — empty figure NPE no longer occurs

## Known limitation

CSS floats can escape from their DOM parent in the structure tree. Workaround: use `display: table-cell` instead of `float: left` for multi-column layouts, consistent with the [existing wiki recommendation](https://github.com/danfickle/openhtmltopdf/wiki/PDF-Accessibility-(PDF-UA,-WCAG,-Section-508)-Support).