### PR TITLE
fix(accessibility): guard against null FigureContentItem in finish()

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,6 @@
 language: en
 reviews:
+  profile: assertive
   request_changes_workflow: false
   high_level_summary: true
   poem: false
@@ -11,5 +12,50 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+  tools:
+    eslint:
+      enabled: false
+    biome:
+      enabled: false
+    oxlint:
+      enabled: false
+    ruff:
+      enabled: false
+    pylint:
+      enabled: false
+    swiftlint:
+      enabled: false
+    shellcheck:
+      enabled: false
+    hadolint:
+      enabled: false
+    checkov:
+      enabled: false
+    tflint:
+      enabled: false
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    pmd:
+      enabled: true
+    detekt:
+      enabled: false
+    markdownlint:
+      enabled: true
+    rubocop:
+      enabled: false
+    buf:
+      enabled: false
+    phpstan:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    cppcheck:
+      enabled: false
+    semgrep:
+      enabled: true
+    gitleaks:
+      enabled: true
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+language: en
+reviews:
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  path_filters:
+    - "!**/*.flattened-pom.xml"
+    - "!**/expected*.png"
+    - "!**/actual*.png"
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,11 +7,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8','11','17', '21']
+        java: ['8', '11', '17', '21']
 
     steps:
       - uses: actions/checkout@v4
@@ -21,11 +20,42 @@ jobs:
           distribution: temurin
           java-version: ${{matrix.java}}
           cache: maven
-      - name: Maven -v
-        run: mvn -v
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Drevision=${{ github.sha }}
 
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Build and collect coverage
+        run: mvn -B test --file pom.xml -Drevision=${{ github.sha }}
+      - name: Generate JaCoCo badge
+        uses: cicirello/jacoco-badge-generator@v2
+        id: jacoco
+        with:
+          jacoco-csv-file: "**/target/site/jacoco/jacoco.csv"
+          on-missing-report: quiet
+          generate-branches-badge: true
+          generate-summary: true
+      - name: Add coverage to PR
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: |
+            **/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
+          title: Code Coverage
 
   release-dev:
     name: Create release - dev
@@ -44,7 +74,10 @@ jobs:
           distribution: temurin
           java-version: 8
           cache: maven
-      - name: Upload artifact
-        run: mvn -B deploy -Dgithub-release -e -Drevision=dev-${{ github.sha }}
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+      - name: Deploy dev snapshot to GitHub Packages
+        run: mvn -B deploy -e -Drevision=dev-${{ github.sha }}-SNAPSHOT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,7 +43,7 @@ jobs:
         uses: cicirello/jacoco-badge-generator@v2
         id: jacoco
         with:
-          jacoco-csv-file: "**/target/site/jacoco/jacoco.csv"
+          jacoco-csv-file: "openhtmltopdf-examples/target/site/jacoco-aggregate/jacoco.csv"
           on-missing-report: quiet
           generate-branches-badge: true
           generate-summary: true
@@ -51,7 +51,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: |
-            **/target/site/jacoco/jacoco.xml
+            openhtmltopdf-examples/target/site/jacoco-aggregate/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 0
           min-coverage-changed-files: 0

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,28 +56,3 @@ jobs:
           min-coverage-overall: 0
           min-coverage-changed-files: 0
           title: Code Coverage
-
-  release-dev:
-    name: Create release - dev
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
-      - name: Deploy dev snapshot to GitHub Packages
-        run: mvn -B deploy -e -Drevision=dev-${{ github.sha }}-SNAPSHOT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17','21']
-    if: github.repository_owner == 'openhtmltopdf'
+        java: ['8', '11', '17', '21']
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{matrix.java}}
@@ -24,56 +22,50 @@ jobs:
           distribution: temurin
           java-version: ${{matrix.java}}
           cache: maven
-      - name: Maven -v
-        run: mvn -v
       - name: Build with Maven
         run: mvn -B package --file pom.xml -Drevision=${{ github.sha }}
 
   release:
-    name: Create release
+    name: Publish to GitHub Packages
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
       packages: write
     steps:
-      - name: Step 1 - Checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
-      - name: Step 2 - Import GPG key
-        run: |
-          echo "${{ secrets.GPG_PUBLIC_KEY }}" | gpg --import
-          echo "${{ secrets.GPG_SECRET_KEY }}" | gpg --import --no-tty --batch --yes
-      - name: Step 3 - Setup Java
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 8
           cache: maven
-      - name: Step 4 - Get next version
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+      - name: Get next version
         uses: reecetech/version-increment@2023.9.3
         id: version
         with:
           scheme: semver
           increment: patch
-      - name: Step 5 - Prepare and perform release
-        run: mvn -B deploy --no-transfer-progress -e -Prelease -Drevision=${{ steps.version.outputs.version }} -s settings.xml
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      - name: Step 6 - Upload artifact to GitHub Package Registry
-        run: mvn -B deploy -Dgithub-release -Drevision=${{ steps.version.outputs.version }}
+      - name: Deploy to GitHub Packages
+        run: mvn -B deploy --no-transfer-progress -Drevision=${{ steps.version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Step 7 - Push Git tag for the new release
+      - name: Push Git tag
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
         with:
           tag: ${{ steps.version.outputs.version }}
           tag_exists_error: false
-      - name: Step 8 - Create GitHub release
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
-          gh release create '${{ steps.version.outputs.version }}' -t openhtmltopdf --generate-notes
+          gh release create '${{ steps.version.outputs.version }}' -t 'openhtmltopdf ${{ steps.version.outputs.version }}' --generate-notes

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -1,0 +1,159 @@
+# Fork Changes — psylector/openhtmltopdf
+
+This document summarizes all changes made in the [psylector/openhtmltopdf](https://github.com/psylector/openhtmltopdf) fork relative to the upstream [nicehash/openhtmltopdf](https://github.com/nicehash/openhtmltopdf) (commit `9dc941bc`).
+
+These changes are intended for contribution back to the upstream project.
+
+## Summary
+
+The fork focuses on **PDF/UA-1 (ISO 14289-1) accessibility compliance**. Three bugs were fixed and validated with veraPDF and manual PDF structure tree inspection.
+
+---
+
+## Release 1.1.38 — Fork setup
+
+**PR:** [#1](https://github.com/psylector/openhtmltopdf/pull/1)
+**Commit:** `b3f2bb53`
+**Ticket:** PSY-76
+
+Build/CI-only changes to repackage the fork. **No code changes relevant for upstream.**
+
+- Changed Maven groupId from `io.github.openhtmltopdf` to `cz.psylector.openhtmltopdf`
+- Replaced Maven Central publishing with GitHub Packages
+- Added JaCoCo code coverage reporting to CI
+- Added CodeRabbit configuration
+
+---
+
+## Release 1.1.39 — Fix structure tree DOM ordering
+
+**PR:** [#2](https://github.com/psylector/openhtmltopdf/pull/2)
+**Commit:** `9450e513`
+**Ticket:** PSY-77
+
+### Problem
+
+The PDF structure tree was built in CSS paint order (floats first, then normal flow) instead of DOM document order. This violates **PDF/UA-1 rule 7.4.2-1** which requires the structure tree to reflect the logical reading order of the document.
+
+For example, a document with `<h1>`, `<h2>`, `<h3>` could produce a structure tree with H3 before H1 if CSS floats reordered the paint sequence.
+
+### Fix
+
+Added `sortChildrenByDomOrder()` in `PdfBoxAccessibilityHelper` that recursively reorders structure tree children using `Node.compareDocumentPosition()` before the tree is finalized. Only items with a DOM node are sorted; anonymous boxes and text runs stay in their original positions to preserve inline content ordering.
+
+### Files changed (upstream-relevant)
+
+- `openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java`
+
+### Tests added
+
+- `NonVisualRegressionTest.testStructureTreeFollowsDomOrder` — verifies H1→H2→H3 ordering in structure tree
+
+### Known limitation
+
+CSS floats can escape from their DOM parent in the structure tree. Workaround: use `display: table-cell` instead of `float: left` for multi-column layouts. This is consistent with the [OpenHTMLtoPDF wiki recommendation](https://github.com/danfickle/openhtmltopdf/wiki/PDF-Accessibility-(PDF-UA,-WCAG,-Section-508)-Support).
+
+---
+
+## Release 1.1.40 (pending) — Fix links in running footers
+
+**PR:** [#3](https://github.com/psylector/openhtmltopdf/pull/3)
+**Commit:** `c836d8b3`
+**Ticket:** PSY-78
+
+### Problem
+
+Links inside running headers/footers (`position: running()`) were painted entirely as pagination artifacts. Link annotations existed in the PDF but had no corresponding `/Link` structure elements, violating:
+
+- **PDF/UA-1 rule 7.18.1-2** — Link annotations shall be nested within a `/Link` structure element
+- **PDF/UA-1 rule 7.18.5-1** — `/Link` shall contain an OBJR (object reference to the annotation)
+- **PDF/UA-1 rule 7.18.5-2** — `/Link` shall include tagged content identifying the link text
+
+### Root cause
+
+`SimplePainter` (used for running content) does not participate in the structure tree — it paints everything as artifacts. The `DisplayListPainter` (used for normal content) calls `startStructure()`/`endStructure()` but `SimplePainter` does not.
+
+### Fix
+
+Implemented a hybrid artifact/structure approach in `PdfBoxAccessibilityHelper`:
+
+1. When painting running content and an anchor element is detected (via DOM ancestry walk), temporarily close the artifact BMC
+2. Emit MCID-tagged content under a `/Link` structure element
+3. Reopen the artifact BMC
+4. A DOM-element-based cache ensures the `/Link` structure is reused when the same running element appears on multiple pages
+
+Additional fixes in the same PR:
+
+- **SimplePainter**: Added `startStructure(REPLACED)`/`endStructure()` calls for replaced elements (images), matching `DisplayListPainter` behavior
+- **Image links**: Route REPLACED content through `FigureStructualElement` to preserve alt text and BBox
+- **OBJR for image-only links**: Fall back to `_runningLinkCache` in `addLink()` when anchor box lacks accessibility object
+- **CI**: Switched coverage reporting to JaCoCo `report-aggregate` for accurate cross-module data
+
+### Files changed (upstream-relevant)
+
+- `openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java`
+- `openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java`
+
+### Tests added
+
+- `NonVisualRegressionTest.testRunningFooterLinksGetLinkStructureElements` — /Link with OBJR + MCID content
+- `NonVisualRegressionTest.testRunningFooterLinkAnnotationPosition` — annotation rect in bottom margin
+- `NonVisualRegressionTest.testRunningFooterLinkAcrossMultiplePages` — single /Link with 2 OBJRs across pages
+- `NonVisualRegressionTest.testRunningFooterMultipleLinks` — 2 distinct /Link elements
+- `NonVisualRegressionTest.testRunningFooterImageLinkGetsFigureStructure` — /Figure with alt text under /Link
+- `NonVisualRegressionTest.testRunningFooterLinkMultipleSpansReusesStructure` — cache reuse verification
+
+---
+
+## Current branch (PSY-82) — veraPDF PDF/UA-1 validation + page-break heading test
+
+**Branch:** `psylector/psy-82-add-verapdf-validation-and-page-break-structure-tree-tests`
+**Ticket:** PSY-82
+
+### Changes
+
+#### 1. veraPDF PDF/UA-1 validation tests
+
+New test class `PdfUaTester` in `openhtmltopdf-pdfa-testing` validates generated PDFs against the `PDFUA_1` veraPDF profile (already available in veraPDF 1.18.8). Two tests:
+
+- `testAllInOnePdfUa1` — validates the existing comprehensive `all-in-one.html` test document
+- `testStructureWithRunningFooterLinks` — validates a new HTML with heading hierarchy (H1→H2→H3) and running footer links
+
+#### 2. Link annotation Contents key (PDF/UA-1 fix)
+
+veraPDF validation revealed that link annotations were missing the `Contents` key required by PDF/UA-1 (ISO 32000-1:2008, §14.9.3). Added `setLinkContents()` in `PdfBoxFastLinkManager` that sets the alternate description from the `title` attribute (fallback: element text content).
+
+#### 3. Page-break heading structure tree test
+
+New test `testHeadingsAcrossPageBreaksPreserveOrder` in `NonVisualRegressionTest` verifies that headings split across page breaks preserve H1→H2→H3 reading order in the structure tree.
+
+### Files changed (upstream-relevant)
+
+- `openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java` — `setLinkContents()` for PDF/UA-1 compliance
+
+### Files changed (test-only)
+
+- `openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java` (new)
+- `openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-structure.html` (new)
+- `openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java`
+
+---
+
+## PDF/UA-1 rules addressed
+
+| Rule | Description | Fixed in |
+|------|-------------|----------|
+| 7.4.2-1 | Structure tree shall follow logical reading order | 1.1.39 (PSY-77) |
+| 7.18.1-2 | Link annotations shall be nested in /Link structure elements | 1.1.40 (PSY-78) |
+| 7.18.5-1 | /Link shall contain OBJR (annotation object reference) | 1.1.40 (PSY-78) |
+| 7.18.5-2 | /Link shall include tagged content identifying the link | 1.1.40 (PSY-78) |
+| §14.9.3 | Link annotations shall have alternate description (Contents key) | PSY-82 |
+
+## Upstream PR scope
+
+For the upstream contribution, the following changes are relevant (excluding fork-specific build/CI changes):
+
+1. **`PdfBoxAccessibilityHelper.java`** — DOM order sorting + running footer link structure
+2. **`SimplePainter.java`** — `startStructure(REPLACED)` for replaced elements
+3. **`PdfBoxFastLinkManager.java`** — `setLinkContents()` for link annotation alt text
+4. **All test files** — 9 new tests covering the above fixes

--- a/FORK_CHANGES.md
+++ b/FORK_CHANGES.md
@@ -105,9 +105,10 @@ Additional fixes in the same PR:
 
 ---
 
-## Current branch (PSY-82) — veraPDF PDF/UA-1 validation + page-break heading test
+## Release 1.1.41 — veraPDF PDF/UA-1 validation + page-break heading test
 
-**Branch:** `psylector/psy-82-add-verapdf-validation-and-page-break-structure-tree-tests`
+**PR:** [#4](https://github.com/psylector/openhtmltopdf/pull/4)
+**Commit:** `5bd09d98`
 **Ticket:** PSY-82
 
 ### Changes
@@ -126,6 +127,11 @@ veraPDF validation revealed that link annotations were missing the `Contents` ke
 #### 3. Page-break heading structure tree test
 
 New test `testHeadingsAcrossPageBreaksPreserveOrder` in `NonVisualRegressionTest` verifies that headings split across page breaks preserve H1→H2→H3 reading order in the structure tree.
+
+#### 4. CI/config improvements
+
+- Removed unused `release-dev` job from PR workflow (dev SNAPSHOT publishing)
+- CodeRabbit: switched to `assertive` profile, disabled irrelevant linting tools (JS/Python/Go/Docker/etc.), kept pmd, yamllint, actionlint, markdownlint, semgrep, gitleaks
 
 ### Files changed (upstream-relevant)
 
@@ -147,7 +153,7 @@ New test `testHeadingsAcrossPageBreaksPreserveOrder` in `NonVisualRegressionTest
 | 7.18.1-2 | Link annotations shall be nested in /Link structure elements | 1.1.40 (PSY-78) |
 | 7.18.5-1 | /Link shall contain OBJR (annotation object reference) | 1.1.40 (PSY-78) |
 | 7.18.5-2 | /Link shall include tagged content identifying the link | 1.1.40 (PSY-78) |
-| §14.9.3 | Link annotations shall have alternate description (Contents key) | PSY-82 |
+| §14.9.3 | Link annotations shall have alternate description (Contents key) | 1.1.41 (PSY-82) |
 
 ## Upstream PR scope
 
@@ -156,4 +162,4 @@ For the upstream contribution, the following changes are relevant (excluding for
 1. **`PdfBoxAccessibilityHelper.java`** — DOM order sorting + running footer link structure
 2. **`SimplePainter.java`** — `startStructure(REPLACED)` for replaced elements
 3. **`PdfBoxFastLinkManager.java`** — `setLinkContents()` for link annotation alt text
-4. **All test files** — 9 new tests covering the above fixes
+4. **All test files** — 10 new tests (7 in NonVisualRegressionTest + 2 in PdfUaTester + 1 page-break heading test)

--- a/README.md
+++ b/README.md
@@ -1,41 +1,56 @@
-[![build-release](https://github.com/openhtmltopdf/openhtmltopdf/workflows/release/badge.svg)](https://github.com/openhtmltopdf/openhtmltopdf/actions?query=workflow%3Arelease)
+[![build-release](https://github.com/psylector/openhtmltopdf/workflows/release/badge.svg)](https://github.com/psylector/openhtmltopdf/actions?query=workflow%3Arelease)
 
-# OPEN HTML TO PDF
+# OPEN HTML TO PDF (Psylector Fork)
 
-![PDF screenshot of OpenHTMLtoPDF](screenshot.png)
+## WHY THIS FORK?
+
+This is a fork of [openhtmltopdf/openhtmltopdf](https://github.com/openhtmltopdf/openhtmltopdf) maintained by [Psylector](https://github.com/psylector) to fix PDF/UA-1 (accessible PDF) issues that are not yet addressed upstream.
+
+Changes in this fork focus on improving PDF/UA compliance and accessibility support.
+
+## CONSUMING FROM GITHUB PACKAGES
+
+Add the GitHub Packages repository and dependency to your `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/psylector/openhtmltopdf</url>
+  </repository>
+</repositories>
+
+<dependency>
+  <groupId>cz.psylector.openhtmltopdf</groupId>
+  <artifactId>openhtmltopdf-pdfbox</artifactId>
+  <version>LATEST_VERSION</version> <!-- See https://github.com/psylector/openhtmltopdf/packages -->
+</dependency>
+```
+
+You also need to authenticate with GitHub Packages. Add this to your `~/.m2/settings.xml`:
+
+```xml
+<servers>
+  <server>
+    <id>github</id>
+    <username>YOUR_GITHUB_USERNAME</username>
+    <password>YOUR_GITHUB_TOKEN</password>
+  </server>
+</servers>
+```
+
+The token needs the `read:packages` scope.
 
 ## OVERVIEW
-
-This is the community's next iteration of the [OpenHTMLtoPDF project](https://github.com/danfickle/openhtmltopdf).
 
 Open HTML to PDF is a pure-Java library for rendering a reasonable subset of well-formed XML/XHTML (and even some HTML5)
 using CSS 2.1 (and later standards) for layout and formatting, outputting to PDF or images.
 
-## DISCLAIMER
+## UPSTREAM
 
-OpenHTMLtoPDF uses a custom engine to render HTML/CSS (rather than WebKit/Blink/etc.). This engine is not as
-well-maintained or fully-featured, but it is much lighter, allowing it to run significantly faster than alternatives (
-e.g. none of our code pays any attention to JavaScript). As a result, some not-so-gentle massaging is required to
-achieve parity between the PDF output and what is seen in a web browser.
-
-Notably, the CSS flex box and grid layout schemes are not supported. Oftentimes, a modern web page must be re-adapted to
-use older web design practices employing HTML tables or 'floating' inline blocks. Transparency is also not supported, so
-color codes utilizing alpha values or computed opacity will have to be re-formed to use an explicit RGB/HSL value.
-
-The native XML parser cannot interpret the full HTML specification. We recommend users to utilize
-the [Jsoup](https://jsoup.org/) library to pre-emptively parse the HTML file before passing a `Document` object to the
-PDF renderer.
-
-## GETTING STARTED
-
-+ [Maven Central registry](https://central.sonatype.com/namespace/io.github.openhtmltopdf)
++ Upstream repository: [openhtmltopdf/openhtmltopdf](https://github.com/openhtmltopdf/openhtmltopdf)
 + [1.0.10 Online Sandbox](https://sandbox.openhtmltopdf.com/)
-+ [Templates for Openhtmltopdf](https://danfickle.github.io/pdf-templates/index.html)
-    + MIT licensed templates that work with this project. Updated 2021-09-21.
-+ [Showcase Document - PDF](https://openhtmltopdf.com/showcase.pdf)
 + [Documentation wiki](https://github.com/danfickle/openhtmltopdf/wiki)
-    + Note: This documentation is hosted on the old GitHub repository and has yet to be migrated
-+ [Sample Project - Pretty Resume Generator](https://github.com/danfickle/pretty-resume)
 
 ## DIFFERENCES WITH FLYING SAUCER
 
@@ -51,7 +66,6 @@ PDF renderer.
 + Limited support for RTL and bi-directional documents.
 + On the negative side, no support for OpenType fonts.
 + Footnote support.
-+ Much more. See changelog below.
 
 ## LICENSE
 
@@ -62,28 +76,12 @@ way and for any purpose you want as long as you respect the terms of the
 license. A copy of the LGPL license is included as license-lgpl-2.1.txt or license-lgpl-3.txt
 in our distributions and in our source tree.
 
-An exception to this is the pdf-a testing module, which is licensed under the GPL. This module is not distributed to
-Maven Central
-and is for testing only.
-
-Open HTML to PDF uses a couple of FOSS packages to get the job done. A list
-of these can be found in the [dependency graph](https://github.com/openhtmltopdf/openhtmltopdf/network/dependencies).
-
-## ACCREDITATION
-
-Thanks to @danfickle for his work advancing the OpenHtmlToPdf project beyond FlyingSaucer.
-
-Open HTML to PDF is based on [Flying-saucer](https://github.com/flyingsaucerproject/flyingsaucer). Credit goes to the
-contributors of that project. Code will also be used
-from [neoFlyingSaucer](https://github.com/danfickle/neoflyingsaucer)
+An exception to this is the pdf-a testing module, which is licensed under the GPL. This module is not published to GitHub Packages and is for testing only.
 
 ## FAQ
 
 + OPEN HTML TO PDF is tested with Temurin 8, 11, 17 and 21. It requires at least Java 8 to run.
 + No, you can not use it on Android.
-+ You should be able to use it on Google App Engine (Java 8 or greater
-  environment). [Let us know your experience](https://github.com/danfickle/openhtmltopdf/issues/179).
-+ <s>Flowing columns are not implemented.</s> Implemented in RC12.
 + No, it's not a web browser. Specifically, it does not run javascript or implement many modern standards such as flex
   and grid layout.
 
@@ -93,98 +91,3 @@ Test cases, failing or working are welcome, please place them
 in ````/openhtmltopdf-examples/src/main/resources/testcases/````
 and run them
 from ````/openhtmltopdf-examples/src/main/java/com/openhtmltopdf/testcases/TestcaseRunner.java````.
-
-## CHANGELOG
-
-### NEWER VERSIONS: SEE COMMIT LOG BETWEEN TAGS
-
-+ https://github.com/openhtmltopdf/openhtmltopdf/tags
-
-### 1.1.8 (2024-April-26)
-
-+ [#29](https://github.com/openhtmltopdf/openhtmltopdf/pull/29) Update README to clarify fork and differences to old
-  project. Thanks, @XSpielinbox and @siegelzc.
-
-### 1.1.7 (2024-April-26)
-
-+ [ebee9c0](https://github.com/openhtmltopdf/openhtmltopdf/commit/ebee9c0d560fc648674afdc7f38581f65389e078) Don't run
-  release pipeline from forks. Thanks, @madsop-nav.
-+ [cdbd127](https://github.com/openhtmltopdf/openhtmltopdf/commit/cdbd127cba411d47327d2054428a136dbaeba0ff)
-  Automatically publish new versions to Maven Central. Thanks, @madsop-nav.
-
-### 1.1.6 (2024-April-26)
-
-+ [84b2cd0](https://github.com/openhtmltopdf/openhtmltopdf/commit/84b2cd0c660151744545d0f9c230e767ae2caa25) correct
-  release target java version to 8. Thanks, @madsop-nav.
-+ [edd9c53](https://github.com/openhtmltopdf/openhtmltopdf/commit/edd9c53dbd3574aafdbde5466e693c5083f07a69) Use the
-  proper tag. Thanks, @madsop-nav.
-
-### 1.1.5 (2024-April-25)
-
-**NOTE**: This release is only available from GitHub.
-
-+ [#3](https://github.com/openhtmltopdf/openhtmltopdf/pull/3) Support classpath protocol. Thanks, @daniel-shuy and
-  @siegelzc.
-+ [#6](https://github.com/openhtmltopdf/openhtmltopdf/pull/6) Fix compile error. Thanks, @madsop-nav and @siegelzc.
-+ [#4](https://github.com/openhtmltopdf/openhtmltopdf/pull/4) Set lower log level when loading an XML resource. Thanks,
-  @icrnjak.
-+ [#7](https://github.com/openhtmltopdf/openhtmltopdf/pull/7) Updates to the GitHub Actions workflow. Thanks,
-  @madsop-nav.
-+ [#8](https://github.com/openhtmltopdf/openhtmltopdf/pull/8) Improve ClassCondition performance. Thanks, @jochenberger
-  and @siegelzc.
-+ [#11](https://github.com/openhtmltopdf/openhtmltopdf/pull/11) PDFBox version 3 documentation update. Thanks, @siegelzc
-  and @imario42.
-+ [#12](https://github.com/openhtmltopdf/openhtmltopdf/pull/12) Minor dependency updates (pdfbox 3.0.1, graphics2d
-  3.0.1). Thanks, @ganomi and Stefan K.
-+ [#9](https://github.com/openhtmltopdf/openhtmltopdf/pull/9) Release mechanism - every push will trigger a release.
-  Thanks, @madsop-nav.
-+ [#14](https://github.com/openhtmltopdf/openhtmltopdf/pull/14) Fine-tune GitHub Actions and versioning. Thanks,
-  @madsop-nav.
-+ [#17](https://github.com/openhtmltopdf/openhtmltopdf/pull/17) FIX ignored at-rule after unrecognized at-rule. Thanks,
-  @siegelzc and @zachary-foreflight.
-+ [#18](https://github.com/openhtmltopdf/openhtmltopdf/pull/18) Miscellaneous changes following #17. Thanks, @siegelzc
-  and @zachary-foreflight.
-+ [#22](https://github.com/openhtmltopdf/openhtmltopdf/pull/22) Update pdfbox to 3.0.2. Thanks, @piotr-szachewicz.
-+ [#20](https://github.com/openhtmltopdf/openhtmltopdf/pull/20) Release mechanism and change group id to *
-  *io.github.openhtmltopdf**. Thanks, @madsop-nav.
-+ [#33](https://github.com/openhtmltopdf/openhtmltopdf/pull/33) Fix release process bugs. Thanks, @madsop-nav.
-+ [#35](https://github.com/openhtmltopdf/openhtmltopdf/pull/35) Minimize use of hardcoded versions. Thanks, @madsop-nav.
-
-### 1.1.4 (2023-October-1)
-
-+ [9fbf939](https://github.com/openhtmltopdf/openhtmltopdf/commit/9fbf9390b1aac5ac2b0e565611c50ec9d1bb512a) **SECURITY**
-  Update dependencies. Thanks, @imario42.
-
-### 1.1.3 (2023-September-15)
-
-+ [b0a40b7](https://github.com/openhtmltopdf/openhtmltopdf/commit/b0a40b78bcadb0e54b5e116e6a3cc3197f74e7f6) prepare for
-  release. Thanks, @imario42.
-
-### 1.1.2 (2023-September-15)
-
-**NOTE**: This release is only available from GitHub.
-
-+ [729d1ce](https://github.com/openhtmltopdf/openhtmltopdf/commit/729d1ceb7b79c1880e7806a46df9c311c9def5a1) prepare for
-  release. Thanks, @imario42.
-
-### 1.1.1 (2023-September-15)
-
-**NOTE**: This release is only available from GitHub.
-
-+ [ea8a2b9](https://github.com/openhtmltopdf/openhtmltopdf/commit/ea8a2b9111b7b49c228c53b396bd9b1babb33341) prepare for
-  release. Thanks, @imario42.
-
-### 1.1.0 (2023-September-15)
-
-**NOTE**: This is the first release of the community fork. This release is only available from GitHub.
-
-+ [16b6dd5](https://github.com/openhtmltopdf/openhtmltopdf/commit/16b6dd543c49f22fa421f32e77b6316cd0274e9e) Update to
-  PDFBOX 3. Thanks, @imario42.
-+ [99eb141](https://github.com/openhtmltopdf/openhtmltopdf/commit/99eb141b820d6c3c59dcea11890e0af15ac44578) changed
-  maven group id to at.datenwort.openhtmltopdf. Thanks, @imario42.
-+ [260aabf](https://github.com/openhtmltopdf/openhtmltopdf/commit/260aabf0b974726cfc0d03b39175f4db474dfe71) prepare for
-  release. Thanks, @imario42.
-
-### OLDER RELEASES
-
-[View CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -78,6 +78,43 @@ in our distributions and in our source tree.
 
 An exception to this is the pdf-a testing module, which is licensed under the GPL. This module is not published to GitHub Packages and is for testing only.
 
+## KNOWN ISSUES (PDF/UA-1)
+
+### CSS `float` breaks structure tree hierarchy
+
+When `usePdfUaAccessibility(true)` is enabled, floated elements (`float: left`, `float: right`) are placed at the wrong level in the PDF structure tree. The CSS renderer paints floats in a separate layer, and the accessibility helper attaches them as siblings of the document root instead of keeping them inside their DOM parent.
+
+**Example:** For this HTML:
+```html
+<body>
+  <h1>Title</h1>
+  <div style="float: left; width: 50%"><p>Left column</p></div>
+  <div style="float: right; width: 50%"><p>Right column</p></div>
+  <p>Footer</p>
+</body>
+```
+
+The structure tree becomes:
+```text
+Document
+├── Div (body) → H1, P(Footer)   ← normal flow only
+├── Div → P(Left column)          ← float escaped from body
+└── Div → P(Right column)         ← float escaped from body
+```
+
+This violates PDF/UA-1 rule 7.4.2-1 (logical reading order).
+
+**Workaround:** Replace `float` with `display: table` / `table-cell` layout, which produces a correct structure tree:
+
+```html
+<div style="display: table; width: 100%">
+  <div style="display: table-cell; width: 50%"><p>Left column</p></div>
+  <div style="display: table-cell; width: 50%"><p>Right column</p></div>
+</div>
+```
+
+This is an upstream issue inherited from [openhtmltopdf/openhtmltopdf](https://github.com/openhtmltopdf/openhtmltopdf).
+
 ## FAQ
 
 + OPEN HTML TO PDF is tested with Temurin 8, 11, 17 and 21. It requires at least Java 8 to run.

--- a/openhtmltopdf-core/pom.xml
+++ b/openhtmltopdf-core/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -18,36 +18,6 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <packaging>jar</packaging>
 
   <name>Openhtmltopdf Core Renderer</name>

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/simplepainter/SimplePainter.java
@@ -18,6 +18,7 @@ import com.openhtmltopdf.render.OperatorSetClip;
 import com.openhtmltopdf.render.RenderingContext;
 import com.openhtmltopdf.render.displaylist.DisplayListCollector;
 import com.openhtmltopdf.render.displaylist.TransformCreator;
+import com.openhtmltopdf.extend.StructureType;
 
 public class SimplePainter {
     private final int xTranslate;
@@ -174,18 +175,20 @@ public class SimplePainter {
     }
     
     private void paintReplacedElement(RenderingContext c, BlockBox replaced) {
-        
+
         Rectangle contentBounds = replaced.getContentAreaEdge(
                 replaced.getAbsX(), replaced.getAbsY(), c);
-        
+
         // Minor hack:  It's inconvenient to adjust for margins, border, padding during
         // layout so just do it here.
         Point loc = replaced.getReplacedElement().getLocation();
         if (contentBounds.x != loc.x || contentBounds.y != loc.y) {
             replaced.getReplacedElement().setLocation(contentBounds.x, contentBounds.y);
         }
-        
+
+        Object token = c.getOutputDevice().startStructure(StructureType.REPLACED, replaced);
         c.getOutputDevice().paintReplacedElement(c, replaced);
+        c.getOutputDevice().endStructure(token);
     }
 
     private void paintReplacedElements(RenderingContext c, List<DisplayListItem> replaceds) {

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -31,22 +31,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-pdfbox</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-rtl-support</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -61,22 +61,22 @@
             <version>${open.rhino.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-mathml-support</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-java2d</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-objects</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-latex-support</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/openhtmltopdf-examples/pom.xml
+++ b/openhtmltopdf-examples/pom.xml
@@ -130,6 +130,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
@@ -39,6 +40,7 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDObjectReference;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
@@ -1070,6 +1072,380 @@ public class NonVisualRegressionTest {
                 }
                 collectStructureTags(elem, tags, pattern);
             }
+        }
+    }
+
+    /**
+     * Tests that links inside running footers get proper /Link structure elements
+     * instead of being completely hidden inside pagination artifacts (PDF/UA-1 §7.18).
+     */
+    @Test
+    public void testRunningFooterLinksGetLinkStructureElements() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Running Footer Link Test</title>" +
+            "<meta name='description' content='Test running footer links'/>" +
+            "<style>" +
+            "@page { @bottom-center { content: element(footer); } margin-bottom: 50px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><p>Contact: <a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></p></div>" +
+            "<p>Page content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // Find /Link structure elements in the tree.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertFalse("Should find at least one /Link structure element", linkElements.isEmpty());
+
+            // Verify the /Link element has both an OBJR kid (annotation) and content (MCID).
+            PDStructureElement linkElem = linkElements.get(0);
+            boolean hasObjr = false;
+            boolean hasContent = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    hasContent = true;
+                }
+            }
+            assertTrue("/Link should have an OBJR kid (annotation reference)", hasObjr);
+            assertTrue("/Link should have tagged content (MCID)", hasContent);
+        }
+    }
+
+    private static void collectLinkStructureElements(PDStructureNode node, List<PDStructureElement> result) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                if ("Link".equals(elem.getStructureType())) {
+                    result.add(elem);
+                }
+                collectLinkStructureElements(elem, result);
+            }
+        }
+    }
+
+    /**
+     * Diagnostic test: verifies the link annotation rectangle for a running footer link
+     * is positioned within the bottom margin area of the page (not at y=0 or in the content area).
+     */
+    @Test
+    public void testRunningFooterLinkAnnotationPosition() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Link Position Test</title>" +
+            "<meta name='description' content='Test link position'/>" +
+            "<style>" +
+            "@page { size: 200px 400px; margin: 20px 10px 60px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Example'>Click here</a></div>" +
+            "<p>Body text</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDPage page = doc.getPage(0);
+            List<PDAnnotation> annots = page.getAnnotations();
+            assertFalse("Should have at least one annotation", annots.isEmpty());
+
+            PDAnnotationLink linkAnnot = null;
+            for (PDAnnotation a : annots) {
+                if (a instanceof PDAnnotationLink) {
+                    linkAnnot = (PDAnnotationLink) a;
+                    break;
+                }
+            }
+            assertNotNull("Should find a link annotation", linkAnnot);
+
+            PDRectangle rect = linkAnnot.getRectangle();
+            // Page is 400px = 300pt, bottom margin is 60px = 45pt.
+            // The entire link rect should fit inside the bottom margin band (y=0 to ~45pt).
+            float bottomMarginPt = 45f;
+            assertTrue("Link bottom y=" + rect.getLowerLeftY() + " should be > 0",
+                rect.getLowerLeftY() > 0);
+            assertTrue("Link top y=" + rect.getUpperRightY() + " should be in bottom margin (< " + bottomMarginPt + ")",
+                rect.getUpperRightY() < bottomMarginPt);
+            assertTrue("Link should have positive dimensions",
+                rect.getHeight() > 0 && rect.getWidth() > 0);
+        }
+    }
+
+    /**
+     * Tests that running footer links work correctly across multiple pages.
+     * The /Link structure element should be reused (not duplicated) and each page
+     * should have its own link annotation connected via OBJR.
+     */
+    @Test
+    public void testRunningFooterLinkAcrossMultiplePages() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-page Footer Link Test</title>" +
+            "<meta name='description' content='Test multi-page footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 40px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "#footer { position: running(footer); }" +
+            ".break { page-break-before: always; }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+1234567890' title='Call us'>+1 234 567 890</a></div>" +
+            "<p>Page 1</p>" +
+            "<p class='break'>Page 2</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 2 pages", 2, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            // There should be exactly one /Link structure element (reused across pages).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should have exactly one /Link element (reused)", 1, linkElements.size());
+
+            // The /Link should have OBJRs for both pages' annotations.
+            PDStructureElement linkElem = linkElements.get(0);
+            int objrCount = 0;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    objrCount++;
+                }
+            }
+            assertEquals("Should have 2 OBJRs (one per page)", 2, objrCount);
+
+            // Both pages should have link annotations.
+            for (int i = 0; i < 2; i++) {
+                List<PDAnnotation> annots = doc.getPage(i).getAnnotations();
+                boolean hasLink = false;
+                for (PDAnnotation a : annots) {
+                    if (a instanceof PDAnnotationLink) {
+                        hasLink = true;
+                        break;
+                    }
+                }
+                assertTrue("Page " + (i + 1) + " should have a link annotation", hasLink);
+            }
+        }
+    }
+
+    /**
+     * Tests that multiple links in a single running footer each get their own
+     * /Link structure element. Exercises the anchor-switching path in
+     * ensureRunningLinkStructure when _runningLinkDomElement changes.
+     */
+    @Test
+    public void testRunningFooterMultipleLinks() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multiple Footer Links Test</title>" +
+            "<meta name='description' content='Test multiple footer links'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'>" +
+            "  <a href='tel:+123' title='Phone'>Phone</a>" +
+            "  <a href='mailto:a@b.c' title='Email'>Email</a>" +
+            "</div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find 2 /Link structure elements", 2, linkElements.size());
+
+            // Each /Link should have both content (MCID) and annotation (OBJR).
+            for (int i = 0; i < linkElements.size(); i++) {
+                boolean hasObjr = false;
+                boolean hasContent = false;
+                for (Object kid : linkElements.get(i).getKids()) {
+                    if (kid instanceof PDObjectReference) {
+                        hasObjr = true;
+                    } else {
+                        hasContent = true;
+                    }
+                }
+                assertTrue("/Link " + (i + 1) + " should have OBJR", hasObjr);
+                assertTrue("/Link " + (i + 1) + " should have content", hasContent);
+            }
+        }
+    }
+
+    /**
+     * Tests that an image inside a link in a running footer gets a proper /Figure
+     * structure element (with alt text) nested under /Link, not a plain GenericContentItem.
+     * Exercises createRunningLinkFigureItem (StructureType.REPLACED path).
+     */
+    @Test
+    public void testRunningFooterImageLinkGetsFigureStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Image Link Footer Test</title>" +
+            "<meta name='description' content='Test image link in footer'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='https://example.com' title='Logo link'>" +
+            "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='Logo' style='width:10px;height:10px;'/> Home</a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Find /Link structure elements.
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link", 1, linkElements.size());
+
+            PDStructureElement linkElem = linkElements.get(0);
+            // /Link should have an OBJR kid (annotation reference).
+            boolean hasObjr = false;
+            // /Link should have a /Figure child structure element (not just a generic content item).
+            boolean hasFigureChild = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else if (kid instanceof PDStructureElement) {
+                    PDStructureElement childElem = (PDStructureElement) kid;
+                    if ("Figure".equals(childElem.getStructureType())) {
+                        hasFigureChild = true;
+                        // Figure should have alt text.
+                        assertNotNull("Figure should have alt text",
+                            childElem.getAlternateDescription());
+                        assertFalse("Figure alt text should not be empty",
+                            childElem.getAlternateDescription().isEmpty());
+                    }
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have /Figure child with alt text", hasFigureChild);
+        }
+    }
+
+    /**
+     * Tests that a running footer link with multiple text nodes (e.g. icon + label)
+     * reuses the same /Link structure via the cache (exercises _runningLinkCache hit path).
+     */
+    @Test
+    public void testRunningFooterLinkMultipleSpansReusesStructure() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Multi-span Link Footer Test</title>" +
+            "<meta name='description' content='Test multi-span link'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px 10px 50px 10px; " +
+            "  @bottom-center { content: element(footer); } }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 10px; }" +
+            "#footer { position: running(footer); }" +
+            "</style></head><body>" +
+            "<div id='footer'><a href='tel:+123' title='Call'>" +
+            "<span>Icon</span> <span>Call us</span></a></div>" +
+            "<p>Content</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull(root);
+
+            // Should still be exactly one /Link (structure reused for both spans).
+            List<PDStructureElement> linkElements = new ArrayList<>();
+            collectLinkStructureElements(root, linkElements);
+            assertEquals("Should find exactly one /Link (reused)", 1, linkElements.size());
+
+            // The /Link should have multiple content kids (one per text node) plus OBJR.
+            PDStructureElement linkElem = linkElements.get(0);
+            int contentKids = 0;
+            boolean hasObjr = false;
+            for (Object kid : linkElem.getKids()) {
+                if (kid instanceof PDObjectReference) {
+                    hasObjr = true;
+                } else {
+                    contentKids++;
+                }
+            }
+            assertTrue("/Link should have OBJR", hasObjr);
+            assertTrue("/Link should have multiple content kids (>1)", contentKids > 1);
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -39,6 +39,9 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.Assert;
@@ -1006,6 +1009,67 @@ public class NonVisualRegressionTest {
             assertEquals(doc.getPage(2).getMediaBox().getUpperRightY(), dest2.getTop(), 1.0d);
 
             remove("named-destinations-basic", doc);
+        }
+    }
+
+    /**
+     * Tests that the PDF structure tree follows DOM order, not CSS paint order.
+     * CSS paints backgrounds first, then floats, then inlines - which differs
+     * from the DOM order. The structure tree must follow DOM order per
+     * PDF/UA-1 rule 7.4.2-1.
+     */
+    @Test
+    public void testStructureTreeFollowsDomOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Structure Tree Ordering Test</title>" +
+            "<meta name='description' content='Test structure tree DOM ordering'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First</h1>" +
+            "<h2>Second</h2>" +
+            "<h3>Third</h3>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
+    /**
+     * Recursively collects structure element tags matching the given regex pattern
+     * in document order from the PDF structure tree.
+     */
+    private static void collectStructureTags(PDStructureNode node, List<String> tags, String pattern) {
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                PDStructureElement elem = (PDStructureElement) kid;
+                String tag = elem.getStructureType();
+                if (tag != null && tag.matches(pattern)) {
+                    tags.add(tag);
+                }
+                collectStructureTags(elem, tags, pattern);
+            }
         }
     }
 

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -1449,6 +1449,55 @@ public class NonVisualRegressionTest {
         }
     }
 
+    /**
+     * Tests that headings split across page breaks preserve correct reading order
+     * in the structure tree. Page breaks create new branches in the structure tree,
+     * but the heading order must remain H1 → H2 → H3 regardless of page boundaries.
+     */
+    @Test
+    public void testHeadingsAcrossPageBreaksPreserveOrder() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Headings Across Pages Test</title>" +
+            "<meta name='description' content='Test heading order across page breaks'/>" +
+            "<style>" +
+            "@page { size: 200px 200px; margin: 10px; }" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<h1>First heading</h1>" +
+            "<p>Some content on page one.</p>" +
+            "<h2 style='page-break-before: always;'>Second heading on page two</h2>" +
+            "<p>Content on page two.</p>" +
+            "<h3 style='page-break-before: always;'>Third heading on page three</h3>" +
+            "<p>Content on page three.</p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            assertEquals("Should have 3 pages", 3, doc.getNumberOfPages());
+
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<String> headingTags = new ArrayList<>();
+            collectStructureTags(root, headingTags, "H[1-6]");
+
+            assertEquals("Should find 3 headings", 3, headingTags.size());
+            assertEquals("First heading should be H1", "H1", headingTags.get(0));
+            assertEquals("Second heading should be H2", "H2", headingTags.get(1));
+            assertEquals("Third heading should be H3", "H3", headingTags.get(2));
+        }
+    }
+
     // TODO:
     // + More form controls.
     // + Custom meta info.

--- a/openhtmltopdf-java2d/pom.xml
+++ b/openhtmltopdf-java2d/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -22,39 +22,9 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
-      <groupId>io.github.openhtmltopdf</groupId>
+      <groupId>cz.psylector.openhtmltopdf</groupId>
       <artifactId>openhtmltopdf-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/openhtmltopdf-latex-support/pom.xml
+++ b/openhtmltopdf-latex-support/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -22,44 +22,14 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-core</artifactId>
         <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-mathml-support</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/openhtmltopdf-mathml-support/pom.xml
+++ b/openhtmltopdf-mathml-support/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>io.github.openhtmltopdf</groupId>
+		<groupId>cz.psylector.openhtmltopdf</groupId>
 		<artifactId>openhtmltopdf-parent</artifactId>
 		<version>${revision}</version>
 	</parent>
@@ -24,45 +24,14 @@
 			<url>http://www.gnu.org/licenses/lgpl.html</url>
 		</license>
 	</licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-
 	<dependencies>
 		<dependency>
-			<groupId>io.github.openhtmltopdf</groupId>
+			<groupId>cz.psylector.openhtmltopdf</groupId>
 			<artifactId>openhtmltopdf-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.github.openhtmltopdf</groupId>
+			<groupId>cz.psylector.openhtmltopdf</groupId>
 			<artifactId>openhtmltopdf-svg-support</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/openhtmltopdf-objects/pom.xml
+++ b/openhtmltopdf-objects/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>io.github.openhtmltopdf</groupId>
+		<groupId>cz.psylector.openhtmltopdf</groupId>
 		<artifactId>openhtmltopdf-parent</artifactId>
 		<version>${revision}</version>
 	</parent>
@@ -24,37 +24,6 @@
 			<url>http://www.gnu.org/licenses/lgpl.html</url>
 		</license>
 	</licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -63,7 +32,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.github.openhtmltopdf</groupId>
+			<groupId>cz.psylector.openhtmltopdf</groupId>
 			<artifactId>openhtmltopdf-pdfbox</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/openhtmltopdf-pdfa-testing/pom.xml
+++ b/openhtmltopdf-pdfa-testing/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -25,12 +25,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.github.openhtmltopdf</groupId>
+      <groupId>cz.psylector.openhtmltopdf</groupId>
       <artifactId>openhtmltopdf-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.openhtmltopdf</groupId>
+      <groupId>cz.psylector.openhtmltopdf</groupId>
       <artifactId>openhtmltopdf-pdfbox</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
+++ b/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
@@ -119,4 +119,16 @@ public class PdfUaTester {
     public void testStructureWithRunningFooterLinks() throws Exception {
         assertTrue(run("pdfua-structure"));
     }
+
+    /**
+     * Verifies that empty img elements (no src or broken src) do not cause
+     * NPE in FigureStructualElement.finish() when building the PDF/UA
+     * structure tree. The FigureContentItem may be null if no content was
+     * painted for the replaced element.
+     */
+    @Test
+    public void testEmptyFigureDoesNotCauseNpe() throws Exception {
+        // Should not throw NPE — compliance is not required, just no crash.
+        run("pdfua-figure-empty");
+    }
 }

--- a/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
+++ b/openhtmltopdf-pdfa-testing/src/test/java/com/openhtmltopdf/pdfa/testing/PdfUaTester.java
@@ -1,0 +1,122 @@
+package com.openhtmltopdf.pdfa.testing;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.apache.pdfbox.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.verapdf.pdfa.Foundries;
+import org.verapdf.pdfa.PDFAParser;
+import org.verapdf.pdfa.PDFAValidator;
+import org.verapdf.pdfa.VeraGreenfieldFoundryProvider;
+import org.verapdf.pdfa.VeraPDFFoundry;
+import org.verapdf.pdfa.flavours.PDFAFlavour;
+import org.verapdf.pdfa.results.TestAssertion;
+import org.verapdf.pdfa.results.TestAssertion.Status;
+import org.verapdf.pdfa.results.ValidationResult;
+
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceControlPriority;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.util.XRLog;
+
+/**
+ * PDF/UA-1 validation tests using veraPDF.
+ * Validates structure tree ordering (rule 7.4.2-1) and link structure (rules 7.18.x).
+ */
+public class PdfUaTester {
+    @BeforeClass
+    public static void initialize() {
+        VeraGreenfieldFoundryProvider.initialise();
+        XRLog.listRegisteredLoggers().forEach(log -> XRLog.setLevel(log, Level.WARNING));
+    }
+
+    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(keyExtractor.apply(t));
+    }
+
+    private boolean run(String resource) throws Exception {
+        byte[] htmlBytes;
+        try (InputStream is = PdfUaTester.class.getResourceAsStream("/html/" + resource + ".html")) {
+            if (is == null) {
+                throw new IllegalStateException("HTML resource /html/" + resource + ".html not found");
+            }
+            htmlBytes = IOUtils.toByteArray(is);
+        }
+        String html = new String(htmlBytes, StandardCharsets.UTF_8);
+
+        Files.createDirectories(Paths.get("target/test/artefacts/"));
+        if (!Files.exists(Paths.get("target/test/artefacts/Karla-Bold.ttf"))) {
+            try (InputStream in = PdfUaTester.class.getResourceAsStream("/fonts/Karla-Bold.ttf")) {
+                if (in == null) {
+                    throw new IllegalStateException("Font resource /fonts/Karla-Bold.ttf not found");
+                }
+                Files.write(Paths.get("target/test/artefacts/Karla-Bold.ttf"), IOUtils.toByteArray(in));
+            }
+        }
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.usePdfVersion(1.7f);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(new File("target/test/artefacts/Karla-Bold.ttf"), "TestFont");
+        builder.withHtmlContent(html, PdfUaTester.class.getResource("/html/").toString());
+        builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_AFTER_RESOLVING_URI);
+        builder.useExternalResourceAccessControl((uri, type) -> true, ExternalResourceControlPriority.RUN_BEFORE_RESOLVING_URI);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        builder.toStream(baos);
+        builder.run();
+        byte[] pdfBytes = baos.toByteArray();
+
+        Files.createDirectories(Paths.get("target/test/pdf/"));
+        Files.write(Paths.get("target/test/pdf/" + resource + "--PDFUA_1.pdf"), pdfBytes);
+
+        PDFAFlavour flavour = PDFAFlavour.PDFUA_1;
+
+        try (VeraPDFFoundry foundry = Foundries.defaultInstance();
+             InputStream is = new ByteArrayInputStream(pdfBytes);
+             PDFAValidator validator = foundry.createValidator(flavour, true);
+             PDFAParser parser = foundry.createParser(is, flavour)) {
+
+            ValidationResult result = validator.validate(parser);
+
+            List<TestAssertion> asserts = result.getTestAssertions().stream()
+                    .filter(ta -> ta.getStatus() == Status.FAILED)
+                    .filter(distinctByKey(TestAssertion::getRuleId))
+                    .collect(Collectors.toList());
+
+            String errs = asserts.stream()
+                    .map(ta -> String.format("%s\n    %s", ta.getMessage().replaceAll("\\s+", " "), ta.getLocation().getContext()))
+                    .collect(Collectors.joining("\n    ", "[\n    ", "\n]"));
+
+            System.err.format("\nDISTINCT ERRORS(%s--PDFUA_1) (%d): %s\n", resource, asserts.size(), errs);
+
+            return asserts.isEmpty() && result.isCompliant();
+        }
+    }
+
+    @Test
+    public void testAllInOnePdfUa1() throws Exception {
+        assertTrue(run("all-in-one"));
+    }
+
+    @Test
+    public void testStructureWithRunningFooterLinks() throws Exception {
+        assertTrue(run("pdfua-structure"));
+    }
+}

--- a/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-figure-empty.html
+++ b/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-figure-empty.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="EN-US">
+<head>
+  <title>PDF/UA Figure Empty Content Test</title>
+  <meta name="subject" content="PDF/UA figure with no content"/>
+  <meta name="author" content="openhtmltopdf.com team"/>
+  <meta name="description" content="Tests that empty img elements do not cause NPE in structure tree"/>
+
+  <bookmarks>
+    <bookmark name="Figures" href="#figures"/>
+  </bookmarks>
+
+  <style>
+  @page {
+    margin: 30px 20px 60px 20px;
+  }
+  body {
+    margin: 0;
+    font-family: 'TestFont';
+    font-size: 15px;
+  }
+  </style>
+</head>
+<body>
+  <h1 id="figures">Figure test</h1>
+  <p>Paragraph before empty images.</p>
+
+  <!-- Empty img with no src - should not cause NPE in FigureStructualElement.finish() -->
+  <img alt="Empty image placeholder"/>
+
+  <!-- Broken src that will not resolve -->
+  <img src="" alt="Empty src image"/>
+
+  <p>Paragraph after empty images.</p>
+</body>
+</html>

--- a/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-structure.html
+++ b/openhtmltopdf-pdfa-testing/src/test/resources/html/pdfua-structure.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="EN-US">
+<head>
+  <title>PDF/UA Structure Test</title>
+  <meta name="subject" content="PDF/UA structure validation"/>
+  <meta name="author" content="openhtmltopdf.com team"/>
+  <meta name="description" content="Tests heading order and link structure for PDF/UA-1"/>
+
+  <bookmarks>
+    <bookmark name="Main heading" href="#main"/>
+    <bookmark name="Section" href="#section"/>
+    <bookmark name="Subsection" href="#subsection"/>
+    <bookmark name="Links" href="#links"/>
+  </bookmarks>
+
+  <style>
+  @page {
+    margin: 30px 20px 60px 20px;
+
+    @bottom-center {
+      font-family: 'TestFont';
+      font-size: 12px;
+      content: element(footer);
+    }
+  }
+  body {
+    margin: 0;
+    font-family: 'TestFont';
+    font-size: 15px;
+  }
+  #footer {
+    position: running(footer);
+  }
+  </style>
+</head>
+<body>
+  <div id="footer">
+    <p>Contact: <a href="https://openhtmltopdf.com" title="Visit homepage">openhtmltopdf.com</a></p>
+  </div>
+
+  <h1 id="main">Main heading</h1>
+  <p>First paragraph with enough text to fill some space on the page.</p>
+
+  <h2 id="section">Section heading</h2>
+  <p>Second paragraph with content under the section heading.</p>
+
+  <h3 id="subsection">Subsection heading</h3>
+  <p>Third paragraph with content under the subsection heading.</p>
+
+  <h2 id="links">Links section</h2>
+  <p>This is a link to the <a title="The openhtmltopdf.com homepage" href="https://openhtmltopdf.com">homepage</a>.</p>
+  <p>This is an internal link to the <a title="Go to top" href="#main">top</a> of the document.</p>
+</body>
+</html>

--- a/openhtmltopdf-pdfbox/pom.xml
+++ b/openhtmltopdf-pdfbox/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -25,36 +25,6 @@
             <url>http://www.gnu.org/licenses/lgpl.html</url>
         </license>
     </licenses>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -73,7 +43,7 @@
             <version>${pdfbox.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -766,7 +766,9 @@ public class PdfBoxAccessibilityHelper {
 
             child.parentElem.appendKid(child.elem);
 
-            finishTreeItem(child.content, child);
+            if (child.content != null) {
+                finishTreeItem(child.content, child);
+            }
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -3,6 +3,8 @@ package com.openhtmltopdf.pdfboxout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,6 +28,7 @@ import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDMarkedConte
 import org.apache.pdfbox.pdmodel.documentinterchange.taggedpdf.StandardStructureTypes;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
@@ -839,6 +842,7 @@ public class PdfBoxAccessibilityHelper {
             root.appendKid(rootElem);
 
             _root.elem = rootElem;
+            sortChildrenByDomOrder(_root);
             finishTreeItems(_root.children, _root);
 
             _od.getWriter().getDocumentCatalog().setStructureTreeRoot(root);
@@ -894,6 +898,101 @@ public class PdfBoxAccessibilityHelper {
         } else {
             return StandardStructureTypes.SPAN;
         }
+    }
+
+    /**
+     * Recursively sorts children of GenericStructualElement nodes by DOM document order.
+     * This fixes PDF/UA-1 rule 7.4.2-1 where structure tree order must follow logical
+     * reading order (DOM order), not CSS paint order.
+     *
+     * Table and list structures are excluded as they have their own semantic ordering.
+     */
+    private static void sortChildrenByDomOrder(AbstractStructualElement element) {
+        if (element instanceof GenericStructualElement) {
+            GenericStructualElement generic = (GenericStructualElement) element;
+            sortByDomOrder(generic.children);
+            for (AbstractTreeItem child : generic.children) {
+                if (child instanceof AbstractStructualElement) {
+                    sortChildrenByDomOrder((AbstractStructualElement) child);
+                }
+            }
+        } else if (element instanceof ListStructualElement) {
+            ListStructualElement list = (ListStructualElement) element;
+            sortByDomOrder(list.listItems);
+            for (ListItemStructualElement item : list.listItems) {
+                sortChildrenByDomOrder(item);
+            }
+        } else if (element instanceof ListItemStructualElement) {
+            ListItemStructualElement item = (ListItemStructualElement) element;
+            sortChildrenByDomOrder(item.body);
+        } else if (element instanceof TableStructualElement) {
+            TableStructualElement table = (TableStructualElement) element;
+            sortByDomOrder(table.tbodies);
+            sortChildrenByDomOrder(table.thead);
+            for (TableBodyStructualElement tbody : table.tbodies) {
+                sortChildrenByDomOrder(tbody);
+            }
+            sortChildrenByDomOrder(table.tfoot);
+        }
+    }
+
+    /**
+     * Sorts items that have a DOM node by document order, leaving items
+     * without a DOM node (anonymous boxes, text runs) in their original
+     * positions. This avoids Comparator transitivity issues that arise
+     * when mixing DOM-based and index-based ordering in a single sort.
+     */
+    private static <T extends AbstractTreeItem> void sortByDomOrder(List<T> children) {
+        if (children.size() < 2) {
+            return;
+        }
+
+        // Collect anchored items (those with a DOM node) and their positions.
+        List<Integer> anchoredIndices = new ArrayList<>();
+        List<T> anchoredItems = new ArrayList<>();
+
+        for (int i = 0; i < children.size(); i++) {
+            if (getDomNode(children.get(i)) != null) {
+                anchoredIndices.add(i);
+                anchoredItems.add(children.get(i));
+            }
+        }
+
+        if (anchoredItems.size() < 2) {
+            return;
+        }
+
+        // Sort anchored items by DOM document order.
+        Collections.sort(anchoredItems, new Comparator<T>() {
+            @Override
+            public int compare(T a, T b) {
+                Node nodeA = getDomNode(a);
+                Node nodeB = getDomNode(b);
+
+                short pos = nodeA.compareDocumentPosition(nodeB);
+                if ((pos & Node.DOCUMENT_POSITION_FOLLOWING) != 0) {
+                    return -1;
+                } else if ((pos & Node.DOCUMENT_POSITION_PRECEDING) != 0) {
+                    return 1;
+                }
+                return 0;
+            }
+        });
+
+        // Write sorted anchored items back into their original slots.
+        for (int i = 0; i < anchoredIndices.size(); i++) {
+            children.set(anchoredIndices.get(i), anchoredItems.get(i));
+        }
+    }
+
+    private static Node getDomNode(AbstractTreeItem item) {
+        if (item instanceof AbstractStructualElement) {
+            Box box = ((AbstractStructualElement) item).box;
+            if (box != null && box.getElement() != null) {
+                return box.getElement();
+            }
+        }
+        return null;
     }
 
     private static void finishTreeItems(List<? extends AbstractTreeItem> children, AbstractStructualElement parent) {

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -65,6 +65,21 @@ public class PdfBoxAccessibilityHelper {
 
     private int _runningLevel;
 
+    /**
+     * When non-null, we are inside a running element that contains a link.
+     * Text content that is a DOM descendant of this link will get proper
+     * /Link structure elements instead of being marked as artifact.
+     */
+    private AnchorStuctualElement _runningLinkStructure;
+    private org.w3c.dom.Element _runningLinkDomElement;
+
+    /**
+     * Maps anchor DOM elements in running content to their /Link structure elements.
+     * Running content box objects are re-created per page, so we track by DOM element
+     * to reuse the same structure element across pages.
+     */
+    private final Map<org.w3c.dom.Element, AnchorStuctualElement> _runningLinkCache = new HashMap<>();
+
     private static Map<String, Supplier<AbstractStructualElement>> createTagSuppliers() {
         Map<String, Supplier<AbstractStructualElement>> suppliers = new HashMap<>();
 
@@ -995,6 +1010,116 @@ public class PdfBoxAccessibilityHelper {
         return null;
     }
 
+    /**
+     * Walks up the DOM from the box's element looking for an {@code <a>} ancestor.
+     * Returns the anchor element or null if not found.
+     */
+    private static org.w3c.dom.Element findAnchorAncestor(Box box) {
+        if (box == null || box.getElement() == null) {
+            return null;
+        }
+        org.w3c.dom.Node node = box.getElement();
+        while (node != null) {
+            if (node instanceof org.w3c.dom.Element && "a".equals(((org.w3c.dom.Element) node).getTagName())) {
+                return (org.w3c.dom.Element) node;
+            }
+            node = node.getParentNode();
+        }
+        return null;
+    }
+
+    /**
+     * Ensures a /Link structure element exists for a running content anchor.
+     * On the first page, creates the structure element and attaches it to the root.
+     * On subsequent pages, reuses the existing one.
+     */
+    private void ensureRunningLinkStructure(Box box, org.w3c.dom.Element anchorElem) {
+        if (_runningLinkStructure != null && _runningLinkDomElement == anchorElem) {
+            return; // Already set up for this anchor on this page.
+        }
+
+        // Running content box objects are re-created per page, so we track by DOM element.
+        AnchorStuctualElement cached = _runningLinkCache.get(anchorElem);
+        if (cached != null) {
+            _runningLinkStructure = cached;
+        } else {
+            AnchorStuctualElement struct = new AnchorStuctualElement();
+            struct.page = _page;
+            struct.box = box;
+            struct.setPdfVersion(_od.getWriter().getVersion());
+            _root.addChild(struct);
+            struct.parent = _root;
+            _runningLinkCache.put(anchorElem, struct);
+            _runningLinkStructure = struct;
+        }
+        _runningLinkDomElement = anchorElem;
+
+        // Set the accessibility object on the current page's anchor box so that
+        // addLink() can find the /Link structure element via getStructualElementForBox().
+        // Running content re-creates box objects per page, so this must be done every time.
+        Box anchorBox = findAnchorBox(box, anchorElem);
+        if (anchorBox != null) {
+            anchorBox.setAccessiblityObject(_runningLinkStructure);
+        }
+    }
+
+    /**
+     * Walks up from a box to find the box whose element matches the anchor element.
+     */
+    private static Box findAnchorBox(Box box, org.w3c.dom.Element anchorElem) {
+        Box current = box;
+        while (current != null) {
+            if (current.getElement() == anchorElem) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    private GenericContentItem createRunningLinkContentItem() {
+        GenericContentItem current = new GenericContentItem();
+        _runningLinkStructure.addChild(current);
+        current.parent = _runningLinkStructure;
+        current.mcid = _nextMcid;
+        current.dict = createMarkedContentDictionary();
+        current.page = _page;
+        _pageItems._contentItems.add(current);
+        return current;
+    }
+
+    /**
+     * Creates a /Figure structure element under the running /Link for REPLACED (image) content.
+     * This preserves alt text and BBox semantics that would be lost with a plain GenericContentItem.
+     */
+    private FigureContentItem createRunningLinkFigureItem(Box box) {
+        FigureStructualElement figure = new FigureStructualElement();
+        figure.page = _page;
+        figure.box = box;
+
+        Rectangle2D rect = PdfBoxFastLinkManager.createTargetArea(
+                _ctx, box, _pageHeight, _transform, _ctx.getPage(), _od);
+        figure.boundingBox = new PDRectangle(
+                (float) rect.getMinX(),
+                (float) rect.getMinY(),
+                (float) rect.getWidth(),
+                (float) rect.getHeight());
+
+        _runningLinkStructure.addChild(figure);
+        figure.parent = _runningLinkStructure;
+
+        FigureContentItem content = new FigureContentItem();
+        figure.addChild(content);
+        content.parent = figure;
+        content.mcid = _nextMcid;
+        content.dict = createMarkedContentDictionary();
+        content.page = _page;
+        figure.content = content;
+
+        _pageItems._contentItems.add(content);
+        return content;
+    }
+
     private static void finishTreeItems(List<? extends AbstractTreeItem> children, AbstractStructualElement parent) {
         for (AbstractTreeItem child : children) {
             child.finish(parent);
@@ -1182,7 +1307,7 @@ public class PdfBoxAccessibilityHelper {
         return dict;
     }
 
-    private COSDictionary createPaginationArtifact(StructureType type, Box box) {
+    private COSDictionary createPaginationArtifact() {
         COSDictionary dict = new COSDictionary();
         dict.setItem(COSName.TYPE, COSName.getPDFName("Pagination"));
         return dict;
@@ -1196,6 +1321,7 @@ public class PdfBoxAccessibilityHelper {
     private static final Token INSIDE_RUNNING = new Token();
     private static final Token STARTING_RUNNING = new Token();
     private static final Token NESTED_RUNNING = new Token();
+    private static final Token RUNNING_LINK_TEXT = new Token();
 
     public Token startStructure(StructureType type, Box box) {
             // Check for items that appear on every page (fixed, running, page margins).
@@ -1204,7 +1330,7 @@ public class PdfBoxAccessibilityHelper {
                 // nested fixed elements).
                 if (_runningLevel == 0) {
                     _runningLevel++;
-                    COSDictionary run = createPaginationArtifact(type, box);
+                    COSDictionary run = createPaginationArtifact();
                     _cs.beginMarkedContent(COSName.ARTIFACT, run);
                     return STARTING_RUNNING;
                 }
@@ -1213,6 +1339,31 @@ public class PdfBoxAccessibilityHelper {
                 return NESTED_RUNNING;
             } else if (_runningLevel > 0) {
                 // We are in a running artifact.
+                // Detect content inside anchor elements to create /Link structure (PDF/UA-1 §7.18).
+                // Note: SimplePainter (used for running content) doesn't emit INLINE structure
+                // calls, so we detect anchors at the TEXT/REPLACED level via DOM ancestry.
+                if (type == StructureType.TEXT || type == StructureType.REPLACED) {
+                    org.w3c.dom.Element anchorElem = findAnchorAncestor(box);
+                    if (anchorElem != null) {
+                        ensureRunningLinkStructure(box, anchorElem);
+                        // Temporarily close the artifact BMC.
+                        _cs.endMarkedContent();
+                        // Create content item attached to the /Link structure element.
+                        GenericContentItem current;
+                        String tag;
+                        if (type == StructureType.REPLACED) {
+                            // Use FigureStructualElement to preserve alt text and BBox.
+                            current = createRunningLinkFigureItem(box);
+                            tag = StandardStructureTypes.Figure;
+                        } else {
+                            current = createRunningLinkContentItem();
+                            tag = StandardStructureTypes.SPAN;
+                        }
+                        _cs.beginMarkedContent(COSName.getPDFName(tag), current.dict);
+                        return RUNNING_LINK_TEXT;
+                    }
+                }
+
                 return INSIDE_RUNNING;
             }
 
@@ -1297,7 +1448,15 @@ public class PdfBoxAccessibilityHelper {
             _runningLevel--;
         } else if (value == STARTING_RUNNING) {
             _runningLevel--;
+            _runningLinkStructure = null;
+            _runningLinkDomElement = null;
             _cs.endMarkedContent();
+        } else if (value == RUNNING_LINK_TEXT) {
+            // Close the Span marked content for the link text.
+            _cs.endMarkedContent();
+            // Re-open the pagination artifact BMC.
+            COSDictionary dict = createPaginationArtifact();
+            _cs.beginMarkedContent(COSName.ARTIFACT, dict);
         }
     }
 
@@ -1310,6 +1469,8 @@ public class PdfBoxAccessibilityHelper {
         this._transform = transform;
         this._pageItems = new PageItems();
         this._pageItemsMap.put(page, this._pageItems);
+        this._runningLinkStructure = null;
+        this._runningLinkDomElement = null;
     }
 
     public void endPage() {
@@ -1323,6 +1484,20 @@ public class PdfBoxAccessibilityHelper {
 
     public void addLink(Box anchor, Box target, PDAnnotation pdAnnotation, PDPage page) {
         PDStructureElement struct = getStructualElementForBox(anchor);
+
+        // For running content links, the anchor box may not have its accessibility object set
+        // (e.g. image-only links where the <a> box is in a different parent chain than the <img> box).
+        // Fall back to the running link cache using the DOM element.
+        if (struct == null && anchor.getElement() != null) {
+            org.w3c.dom.Element anchorElem = findAnchorAncestor(anchor);
+            if (anchorElem != null) {
+                AnchorStuctualElement cached = _runningLinkCache.get(anchorElem);
+                if (cached != null) {
+                    struct = cached.elem;
+                }
+            }
+        }
+
         if (struct != null) {
             // We have to append the link annotationobject reference as a kid of its associated structure element.
             PDObjectReference ref = new PDObjectReference();

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -248,6 +248,7 @@ public class PdfBoxFastLinkManager {
 
                 PDAnnotationLink annot = new PDAnnotationLink();
                 annot.setAction(action);
+                setLinkContents(annot, elem);
 
                 AnnotationContainer annotContainer = new AnnotationContainer.PDAnnotationLinkContainer(annot);
 
@@ -267,6 +268,7 @@ public class PdfBoxFastLinkManager {
 
                 PDAnnotationLink annot = new PDAnnotationLink();
                 annot.setAction(uriAct);
+                setLinkContents(annot, elem);
 
                 annotContainer = new AnnotationContainer.PDAnnotationLinkContainer(annot);
             } else {
@@ -543,6 +545,23 @@ public class PdfBoxFastLinkManager {
             }
         } catch (IOException e) {
             throw new PdfContentStreamAdapter.PdfException("processLink", e);
+        }
+    }
+
+    /**
+     * Sets the Contents key on a link annotation for PDF/UA-1 compliance
+     * (ISO 14289-1, 14.9.3). Uses the title attribute if available,
+     * otherwise falls back to the text content of the element.
+     */
+    private static void setLinkContents(PDAnnotationLink annot, Element elem) {
+        String title = elem.getAttribute("title");
+        if (title != null && !title.isEmpty()) {
+            annot.setContents(title);
+        } else {
+            String text = elem.getTextContent();
+            if (text != null && !text.isEmpty()) {
+                annot.setContents(text.trim());
+            }
         }
     }
 

--- a/openhtmltopdf-rtl-support/pom.xml
+++ b/openhtmltopdf-rtl-support/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -22,36 +22,6 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
 	<groupId>com.ibm.icu</groupId>
@@ -59,7 +29,7 @@
 	<version>59.1</version>
    </dependency>
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-core</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/openhtmltopdf-slf4j/pom.xml
+++ b/openhtmltopdf-slf4j/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -22,36 +22,6 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
         <groupId>org.slf4j</groupId>
@@ -68,13 +38,13 @@
     </dependency>
 
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-core</artifactId>
         <version>${project.version}</version>
     </dependency>
 
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-pdfbox</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>

--- a/openhtmltopdf-svg-support/pom.xml
+++ b/openhtmltopdf-svg-support/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.github.openhtmltopdf</groupId>
+    <groupId>cz.psylector.openhtmltopdf</groupId>
     <artifactId>openhtmltopdf-parent</artifactId>
     <version>${revision}</version>
   </parent>
@@ -22,39 +22,9 @@
       <url>http://www.gnu.org/licenses/lgpl.html</url>
     </license>
   </licenses>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-core</artifactId>
         <version>${project.version}</version>
     </dependency>

--- a/openhtmltopdf-templates/pom.xml
+++ b/openhtmltopdf-templates/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.github.openhtmltopdf</groupId>
+        <groupId>cz.psylector.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-parent</artifactId>
         <version>${revision}</version>
     </parent>
@@ -27,12 +27,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-pdfbox</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.github.openhtmltopdf</groupId>
+            <groupId>cz.psylector.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-svg-support</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.openhtmltopdf</groupId>
+  <groupId>cz.psylector.openhtmltopdf</groupId>
   <artifactId>openhtmltopdf-parent</artifactId>
   <version>${revision}</version>
   <inceptionYear>2004</inceptionYear>
@@ -12,7 +12,7 @@
 
   <name>Openhtmltopdf</name>
   <description>Open-HTML-to-PDF is a HTML and CSS renderer written in Java.  It supports Java2D and PDF output. Open-HTML-to-PDF is a fork of Flying-saucer with additional features.</description>
-  <url>https://github.com/openhtmltopdf/openhtmltopdf</url>
+  <url>https://github.com/psylector/openhtmltopdf</url>
 
   <licenses>
     <license>
@@ -37,9 +37,9 @@
   </modules>
 
   <scm>
-    <connection>scm:git:git://github.com/openhtmltopdf/openhtmltopdf.git</connection>
-    <developerConnection>scm:git:https://github.com/openhtmltopdf/openhtmltopdf.git</developerConnection>
-    <url>git://github.com/openhtmltopdf/openhtmltopdf.git</url>
+    <connection>scm:git:https://github.com/psylector/openhtmltopdf.git</connection>
+    <developerConnection>scm:git:https://github.com/psylector/openhtmltopdf.git</developerConnection>
+    <url>https://github.com/psylector/openhtmltopdf</url>
     <tag>openhtmltopdf-parent-${revision}</tag>
   </scm>
 
@@ -76,87 +76,13 @@
     </developer>
   </developers>
 
-  <profiles>
-    <profile>
-      <id>github-release</id>
-      <activation>
-        <property>
-          <name>github-release</name>
-        </property>
-      </activation>
-      <distributionManagement>
-        <repository>
-          <id>github</id>
-          <name>GitHub Packages</name>
-          <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
-        </repository>
-      </distributionManagement>
-    </profile>
-    <profile>
-      <id>maven-release</id>
-      <activation>
-        <property>
-          <name>!github-release</name>
-        </property>
-      </activation>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>sonatype-nexus-snapshots</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-          <id>sonatype-nexus-staging</id>
-          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-      </distributionManagement>
-    </profile>
-
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <configuration>
-                  <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing
-                    failed: Inappropriate ioctl for device -->
-                  <gpgArguments>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
-                  </gpgArguments>
-                  <passphrase>${env.GPG_PASSPHRASE}</passphrase>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.4.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <publishingServerId>central</publishingServerId>
-              <tokenAuth>true</tokenAuth>
-              <autoPublish>true</autoPublish>
-              <excludeArtifacts>
-                <excludeArtifact>openhtmltopdf-examples</excludeArtifact>
-                <excludeArtifact>openhtmltopdf-pdfa-testing</excludeArtifact>
-                <excludeArtifact>openhtmltopdf-templates</excludeArtifact>
-              </excludeArtifacts>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/psylector/openhtmltopdf</url>
+    </repository>
+  </distributionManagement>
 
   <build>
     <pluginManagement>
@@ -165,16 +91,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.0.0-M1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.0.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -206,19 +122,15 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>5.1.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.12</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <releaseProfiles>maven-release</releaseProfiles>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <goals>deploy</goals>
-        </configuration>
-      </plugin>
-
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -263,6 +175,26 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.6.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/settings.xml
+++ b/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-    <servers>
-        <server>
-            <id>central</id>
-            <username>${env.MAVEN_USERNAME}</username>
-            <password>${env.MAVEN_CENTRAL_TOKEN}</password>
-        </server>
-    </servers>
-</settings>


### PR DESCRIPTION
## Summary
- `FigureStructualElement.content` can be `null` when a replaced element (e.g. empty `<img>`) has no associated `FigureContentItem` added via `addChild()`
- `finish()` unconditionally called `finishTreeItem(child.content, child)`, causing NPE during PDF/UA structure tree building
- Added null-check before the call

## Reproduction
Template `DOKYC_PDF_AML_QUESTIONNAIRE_PO` with `isPdfUaStrict=true` triggers:
```
Cannot invoke "...AbstractTreeItem.finish(...AbstractStructualElement)" because "item" is null
```

## Test plan
- [ ] Render `DOKYC_PDF_AML_QUESTIONNAIRE_PO` with PDF/UA-1 strict mode — should no longer throw NPE
- [ ] Existing veraPDF PDF/UA-1 tests still pass
- [ ] Run PDF/UA-1 bulk validation across all 112 APPROVED PDF templates