### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.1.x (io.github.openhtmltopdf) | :white_check_mark: |
+| 1.0.x (com.openhtmltopdf) | :x: Unmaintained |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub Issues.
+
+Use GitHub's private vulnerability reporting instead:
+1. Go to the [Security tab](../../security) of this repository
+2. Click **"Report a vulnerability"**
+3. Fill in the details and submit
+
+We will acknowledge receipt within 7 days and aim to provide a fix or mitigation within 90 days.
+
+## Security Considerations
+
+openhtmltopdf renders HTML to PDF and **fetches external resources** (CSS, images, fonts) during rendering.
+
+**If your application renders user-supplied HTML**, be aware that:
+
+- External resource URLs in the HTML will be fetched by the renderer
+- HTTP redirects are followed automatically by the underlying `HttpURLConnection`
+- The default `NaiveUserAgent` applies no URL filtering
+
+**Recommended mitigations:**
+- Only render trusted HTML input
+- Configure `AccessController` to restrict fetchable URLs to an allowlist
+- Consider disabling external resource loading entirely for untrusted input
+
+## Scope
+
+Vulnerabilities in the following areas are in scope:
+- Resource loading (`NaiveUserAgent`, `FSStreamFactory`)
+- XML/SVG parsing (Batik integration)
+- PDF output handling


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` file to establish a formal vulnerability reporting policy for the project.

**Includes:**
- Supported versions table
- Instructions to use GitHub's private vulnerability reporting (instead of public issues)
- Security considerations for applications rendering user-supplied HTML
- Recommended mitigations for external resource loading risks
- Defined scope for security reports

## Motivation

The project currently has no `SECURITY.md`, meaning users and security researchers have no documented channel for responsible disclosure. This PR addresses that gap.

## Test plan

- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Confirm "Report a vulnerability" link works from Security tab