### PR TITLE
Make font matching case-insensitive, as per css spec

### DIFF
--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -30,6 +30,7 @@ import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
@@ -1609,6 +1610,41 @@ public class NonVisualRegressionTest {
             assertEquals("Second heading should be H2", "H2", headingTags.get(1));
             assertEquals("Third heading should be H3", "H3", headingTags.get(2));
         }
+    }
+
+    /**
+     * Verifies CSS font-family matching is case-insensitive. A font
+     * registered as "Karla" must be selected when CSS asks for "karla"
+     * (any case).
+     */
+    @Test
+    public void testFontFamilyCaseInsensitive() throws IOException {
+        TestSupport.makeFontFiles();
+
+        String html = "<html><body style='font-family: karla'>Hello case insensitive font</body></html>";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(baos);
+        builder.testMode(true);
+        builder.useFont(new File("target/test/visual-tests/Karla-Bold.ttf"), "Karla");
+        builder.run();
+
+        boolean karlaEmbedded = false;
+        try (PDDocument doc = Loader.loadPDF(baos.toByteArray())) {
+            for (PDPage page : doc.getPages()) {
+                for (COSName fontKey : page.getResources().getFontNames()) {
+                    PDFont font = page.getResources().getFont(fontKey);
+                    if (font != null && font.getName() != null &&
+                        font.getName().toLowerCase(Locale.ROOT).contains("karla")) {
+                        karlaEmbedded = true;
+                        break;
+                    }
+                }
+                if (karlaEmbedded) break;
+            }
+        }
+        assertTrue("Karla must be selected when CSS font-family is lowercase 'karla'", karlaEmbedded);
     }
 
     // TODO:

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
@@ -45,6 +45,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 
 /**
@@ -149,12 +151,16 @@ public class Java2DFontResolver implements FontResolver {
     /**
      * Map of base fonts, from which we can derive a concrete instance at the correct size, weight, etc.
      * Note: The value is initially null until we need the given base font.
+     * Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
+     * section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
      */
-    private final HashMap<String, Font> availableFontsHash = new HashMap<>();
-    
+    private final Map<String, Font> availableFontsHash = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
     private final SharedContext _sharedContext;
 
-    private final HashMap<String, FontFamily<FontDescription>> _fontFamilies = new HashMap<>();
+    // Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
+    // section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
+    private final Map<String, FontFamily<FontDescription>> _fontFamilies = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     
     public Java2DFontResolver(SharedContext sharedCtx, boolean useEnvironmentFonts) {
         _sharedContext = sharedCtx;

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/AbstractFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/AbstractFontStore.java
@@ -9,8 +9,8 @@ import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 public abstract class AbstractFontStore {
     public abstract FontDescription resolveFont(
@@ -43,7 +43,9 @@ public abstract class AbstractFontStore {
         }
 
         static Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> createInitialFontMap() {
-            HashMap<String, FontFamily<PdfBoxFontResolver.FontDescription>> result = new HashMap<>();
+            // Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
+            // section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
+            Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             addCourier(result);
             addTimes(result);
             addHelvetica(result);
@@ -53,7 +55,7 @@ public abstract class AbstractFontStore {
             return result;
         }
 
-        static void addCourier(HashMap<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
+        static void addCourier(Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
             FontFamily<PdfBoxFontResolver.FontDescription> courier = new FontFamily<>("Courier");
 
             courier.addFontDescription(new PdfBoxFontResolver.FontDescription(new PDType1Font(Standard14Fonts.FontName.COURIER_BOLD_OBLIQUE), IdentValue.OBLIQUE, 700));
@@ -66,7 +68,7 @@ public abstract class AbstractFontStore {
             result.put("Courier", courier);
         }
 
-        static void addTimes(HashMap<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
+        static void addTimes(Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
             FontFamily<PdfBoxFontResolver.FontDescription> times = new FontFamily<>("Times");
 
             times.addFontDescription(new PdfBoxFontResolver.FontDescription(new PDType1Font(Standard14Fonts.FontName.TIMES_BOLD_ITALIC), IdentValue.ITALIC, 700));
@@ -78,7 +80,7 @@ public abstract class AbstractFontStore {
             result.put("TimesRoman", times);
         }
 
-        static void addHelvetica(HashMap<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
+        static void addHelvetica(Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> result) {
             FontFamily<PdfBoxFontResolver.FontDescription> helvetica = new FontFamily<>("Helvetica");
 
             helvetica.addFontDescription(new PdfBoxFontResolver.FontDescription(new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD_OBLIQUE), IdentValue.OBLIQUE, 700));

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FallbackFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/FallbackFontStore.java
@@ -66,14 +66,25 @@ public class FallbackFontStore implements Closeable {
     }
 
     private int getFamilyPriority(String fontFamily, List<String> desiredFamilies) {
+        // Family-name comparison is case-insensitive per the CSS spec (CSS Fonts Level 3,
+        // section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
         if (!desiredFamilies.isEmpty() &&
-            desiredFamilies.get(0).equals(fontFamily)) {
+            desiredFamilies.get(0).equalsIgnoreCase(fontFamily)) {
             return 1;
-        } else if (desiredFamilies.contains(fontFamily)) {
+        } else if (containsIgnoreCase(desiredFamilies, fontFamily)) {
             return 2;
         } else {
             return 3;
         }
+    }
+
+    private static boolean containsIgnoreCase(List<String> list, String value) {
+        for (String s : list) {
+            if (s.equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<FontDescription> resolveFonts(

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/MainFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/MainFontStore.java
@@ -4,9 +4,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.fontbox.ttf.TrueTypeCollection;
 import org.apache.fontbox.ttf.TrueTypeFont;
@@ -27,7 +27,13 @@ import com.openhtmltopdf.pdfboxout.PDFontSupplier;
 import com.openhtmltopdf.pdfboxout.PdfBoxFontResolver.FontDescription;
 
 public class MainFontStore extends AbstractFontStore implements Closeable {
-    private final Map<String, FontFamily<FontDescription>> _fontFamilies = new HashMap<>();
+    // Family-name lookup must be case-insensitive per the CSS spec. CSS Fonts Level 3,
+    // section 5.1 "Case sensitivity of font family names"
+    // (https://www.w3.org/TR/css-fonts-3/#font-family-casing):
+    //   "User agents must match these names case insensitively, using the
+    //    'Default Caseless Matching' algorithm outlined in the Unicode specification."
+    // A CASE_INSENSITIVE_ORDER map keeps this locale-independent (unlike String.toLowerCase()).
+    private final Map<String, FontFamily<FontDescription>> _fontFamilies = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final FSCacheEx<String, FSCacheValue> _fontMetricsCache;
     private final PDDocument _doc;
     private final SharedContext _sharedContext;

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/PDFTranscoder.java
@@ -33,10 +33,10 @@ import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.logging.Level;
 
 public class PDFTranscoder extends SVGAbstractTranscoder {
@@ -82,7 +82,10 @@ public class PDFTranscoder extends SVGAbstractTranscoder {
 	}
 
     public static class OpenHtmlFontResolver implements FontFamilyResolver {
-		private final Map<String, OpenHtmlGvtFontFamily> families = new HashMap<>(4);
+		// Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
+		// section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
+		// Matches Batik's DefaultFontFamilyResolver which lowercases family names.
+		private final Map<String, OpenHtmlGvtFontFamily> families = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 		@Override
 		public GVTFontFamily resolve(String arg0, FontFace arg1) {


### PR DESCRIPTION
Font matching is currently case sensitive, unlike browsers

Fix addresses all these areas affected

- MainFontStore (user fonts)
- BuiltinFontStore (Type1 builtins)
- FallbackFontStore (priority match)
- Java2DFontResolver (user + system fonts)
- PDFTranscoder SVG resolver. 

Added a non visual regression test.

Previously reported in a [2019 comment on danfickle/openhtmltopdf#389](https://github.com/danfickle/openhtmltopdf/issues/389#issuecomment-534972676)
