### PR TITLE
Fix memory leak: cache Font.createFont() results and flush page images

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSSupplier.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/extend/FSSupplier.java
@@ -1,5 +1,32 @@
 package com.openhtmltopdf.extend;
 
 public interface FSSupplier<T> {
+	/**
+	 * Returned by {@link #lastModified()} if the age of the supplied resource is unknown.
+	 */
+	public static final long UNKNOWN_LAST_MODIFIED = 0;
+
 	public T supply();
+
+	/**
+	 * A key that uniquely identifies the resource this supplier supplies, typically the absolute
+	 * URI it is loaded from. Used by caches such as
+	 * {@link com.openhtmltopdf.outputdevice.helper.FontCache}.
+	 *
+	 * <p>The key has to be absolute: a relative URI such as {@code font.ttf} refers to different
+	 * resources depending on the document it appears in. Return null - the default - if no such
+	 * key can be provided, in which case the resource is not cached.</p>
+	 */
+	public default String cacheKey() {
+		return null;
+	}
+
+	/**
+	 * When the supplied resource was last modified, or {@link #UNKNOWN_LAST_MODIFIED} - the
+	 * default - if that can not be determined. A cached resource is reloaded whenever this value
+	 * changes, so implementations may return any value that changes with the resource.
+	 */
+	public default long lastModified() {
+		return UNKNOWN_LAST_MODIFIED;
+	}
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontCache.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontCache.java
@@ -1,0 +1,232 @@
+package com.openhtmltopdf.outputdevice.helper;
+
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.openhtmltopdf.extend.FSSupplier;
+import com.openhtmltopdf.util.OpenUtil;
+
+/**
+ * A process wide cache of AWT fonts.
+ *
+ * <p>Every call to {@link Font#createFont(int, InputStream)} and its siblings registers a font
+ * with the JDK font manager that is never released again, see
+ * <a href="https://bugs.openjdk.org/browse/JDK-8239833">JDK-8239833</a>. Creating the same font
+ * over and over - which is what happens when documents using {@code @font-face} rules or
+ * {@code useFont} are rendered repeatedly - therefore leaks memory (and temporary files) until
+ * the JVM exits. Caching the created fonts avoids that.</p>
+ *
+ * <p>The cache is shared by all renderers and documents. Unlike for example PDFBox fonts, AWT
+ * fonts are immutable and safe to use from more than one document.</p>
+ */
+public class FontCache {
+    private static final ConcurrentHashMap<String, CachedFont> CACHE = new ConcurrentHashMap<>();
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private FontCache() {
+    }
+
+    /**
+     * A font together with the last modified stamp of the resource it was created from.
+     */
+    private static class CachedFont {
+        private final Font font;
+        private final long lastModified;
+
+        private CachedFont(Font font, long lastModified) {
+            this.font = font;
+            this.lastModified = lastModified;
+        }
+    }
+
+    /**
+     * Thrown out of a supplier so that the checked exceptions of {@link Font#createFont(int, File)}
+     * can travel through {@link FSSupplier#supply()}.
+     */
+    private static class FontCreationException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        private FontCreationException(Exception cause) {
+            super(cause);
+        }
+    }
+
+    /**
+     * Returns the cached font for the given key, creating it with the supplier if it is not
+     * cached yet or if the resource it was created from changed.
+     *
+     * @param cacheKey identifies the font resource, or null if the caller can not identify it,
+     *                 in which case the font is created without being cached.
+     * @param lastModified a value that changes whenever the font resource changes, or
+     *                 {@link FSSupplier#UNKNOWN_LAST_MODIFIED} if that can not be determined, in
+     *                 which case the font is cached until {@link #invalidateAll()} is called.
+     * @return the font, or null if the supplier could not supply one.
+     */
+    public static Font get(String cacheKey, long lastModified, FSSupplier<Font> fontSupplier) {
+        if (cacheKey == null) {
+            return fontSupplier.supply();
+        }
+
+        // We use compute rather than computeIfAbsent so that we can also replace entries whose
+        // resource changed. Either way the font is created while holding the lock for its key,
+        // which is what stops concurrent renders from creating - and thus leaking - the same
+        // font more than once.
+        CachedFont cached = CACHE.compute(cacheKey, (key, existing) -> {
+            if (existing != null && existing.lastModified == lastModified) {
+                return existing;
+            }
+
+            Font font = fontSupplier.supply();
+
+            // Returning null removes the mapping, so failures are not cached.
+            return font != null ? new CachedFont(font, lastModified) : null;
+        });
+
+        return cached != null ? cached.font : null;
+    }
+
+    /**
+     * Like {@link #get(String, long, FSSupplier)} with the key and last modified stamp taken from
+     * the supplier itself.
+     */
+    public static Font get(FSSupplier<Font> fontSupplier) {
+        return get(fontSupplier.cacheKey(), fontSupplier.lastModified(), fontSupplier);
+    }
+
+    /**
+     * Returns the true type font in the given file, keyed on its path and reloaded when the file
+     * changes. Does not handle true type collections.
+     */
+    public static Font getTrueTypeFont(File fontFile) throws IOException, FontFormatException {
+        return getChecked("file:" + fontFile.getAbsolutePath(), lastModified(fontFile), () -> createFont(fontFile));
+    }
+
+    /**
+     * Returns the true type font in the given bytes, keyed on a hash of the bytes themselves as
+     * there is no name to key them on.
+     */
+    public static Font getTrueTypeFont(byte[] fontBytes) throws IOException, FontFormatException {
+        return getChecked(contentCacheKey(fontBytes), FSSupplier.UNKNOWN_LAST_MODIFIED,
+                () -> createFont(new ByteArrayInputStream(fontBytes)));
+    }
+
+    /**
+     * Returns the true type font supplied by the given supplier, keyed on
+     * {@link FSSupplier#cacheKey()}.
+     */
+    public static Font getTrueTypeFont(FSSupplier<InputStream> streamSupplier) throws IOException, FontFormatException {
+        return getTrueTypeFont(streamSupplier.cacheKey(), streamSupplier.lastModified(), streamSupplier);
+    }
+
+    /**
+     * Like {@link #getTrueTypeFont(FSSupplier)} but with an explicit key, so that callers can opt
+     * out of caching by passing null.
+     *
+     * @return the font, or null if the supplier did not supply a stream.
+     */
+    public static Font getTrueTypeFont(String cacheKey, long lastModified, FSSupplier<InputStream> streamSupplier)
+            throws IOException, FontFormatException {
+
+        return getChecked(cacheKey, lastModified, () -> {
+            InputStream is = streamSupplier.supply();
+
+            if (is == null) {
+                // The supplier has already logged why.
+                return null;
+            }
+
+            try {
+                return createFont(is);
+            } finally {
+                OpenUtil.closeQuietly(is);
+            }
+        });
+    }
+
+    /**
+     * A cache key derived from the content itself, for fonts that are only available as bytes and
+     * therefore have no stable name to be keyed on.
+     */
+    public static String contentCacheKey(byte[] content) {
+        MessageDigest digest;
+
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            // Every Java implementation has to support SHA-256.
+            throw new IllegalStateException(e);
+        }
+
+        byte[] hash = digest.digest(content);
+        StringBuilder sb = new StringBuilder("sha-256:");
+
+        for (byte b : hash) {
+            sb.append(HEX[(b >> 4) & 0xf]).append(HEX[b & 0xf]);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Removes every font from the cache, for example because font resources changed in a way this
+     * cache can not see, such as a web font served under an unchanged URL.
+     *
+     * <p>Note that fonts already handed to the JDK font manager can not be released, so recreating
+     * the same fonts after clearing the cache will increase memory usage.</p>
+     */
+    public static void invalidateAll() {
+        CACHE.clear();
+    }
+
+    /**
+     * The number of fonts currently cached. Visible for testing.
+     */
+    static int size() {
+        return CACHE.size();
+    }
+
+    /**
+     * The stamp used to detect changes to a font file. Mixes in the length so that a font replaced
+     * within the resolution of the file system timestamp is picked up too.
+     */
+    private static long lastModified(File fontFile) {
+        return (fontFile.lastModified() * 31) + fontFile.length();
+    }
+
+    private static Font getChecked(String cacheKey, long lastModified, FSSupplier<Font> fontSupplier)
+            throws IOException, FontFormatException {
+
+        try {
+            return get(cacheKey, lastModified, fontSupplier);
+        } catch (FontCreationException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw (FontFormatException) e.getCause();
+        }
+    }
+
+    private static Font createFont(File fontFile) {
+        try {
+            return Font.createFont(Font.TRUETYPE_FONT, fontFile);
+        } catch (IOException | FontFormatException e) {
+            throw new FontCreationException(e);
+        }
+    }
+
+    private static Font createFont(InputStream is) {
+        try {
+            return Font.createFont(Font.TRUETYPE_FONT, is);
+        } catch (IOException | FontFormatException e) {
+            throw new FontCreationException(e);
+        }
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplier.java
@@ -2,6 +2,7 @@ package com.openhtmltopdf.outputdevice.helper;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 
 import com.openhtmltopdf.extend.FSSupplier;
@@ -28,5 +29,25 @@ public class FontFaceFontSupplier implements FSSupplier<InputStream> {
         }
         
         return new ByteArrayInputStream(font1);
+    }
+
+    /**
+     * The URI of the font resolved against the base URI of the document, so that the same
+     * relative src - {@code src: url(font.ttf)} - in two documents does not share a cache entry.
+     */
+    @Override
+    public String cacheKey() {
+        String resolved = ctx.getUserAgentCallback().resolveURI(src);
+
+        if (resolved == null) {
+            // A relative URI without a base URI, so we can not tell which font this is.
+            return null;
+        }
+
+        // A data URI carries the font itself, so key on its content instead of holding on to a
+        // string that can be megabytes long.
+        return resolved.startsWith("data:") ?
+                FontCache.contentCacheKey(resolved.getBytes(StandardCharsets.UTF_8)) :
+                resolved;
     }
 }

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/outputdevice/helper/FontCacheTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/outputdevice/helper/FontCacheTest.java
@@ -1,0 +1,191 @@
+package com.openhtmltopdf.outputdevice.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Font;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.openhtmltopdf.extend.FSSupplier;
+
+/**
+ * Tests the caching behavior of {@link FontCache}. Uses logical fonts rather than fonts created
+ * with {@code Font.createFont} as those would be leaked by the JDK, which is what this cache is
+ * there to prevent in the first place.
+ */
+public class FontCacheTest {
+    private final AtomicInteger created = new AtomicInteger();
+
+    private final FSSupplier<Font> supplier = () -> {
+        created.incrementAndGet();
+        return new Font(Font.SANS_SERIF, Font.PLAIN, 1);
+    };
+
+    @Before
+    public void emptyCache() {
+        FontCache.invalidateAll();
+    }
+
+    @Test
+    public void testFontIsCreatedOncePerKey() {
+        Font first = FontCache.get("font-1", 0, supplier);
+        Font second = FontCache.get("font-1", 0, supplier);
+
+        assertSame(first, second);
+        assertEquals(1, created.get());
+    }
+
+    @Test
+    public void testDifferentKeysGetDifferentFonts() {
+        Font first = FontCache.get("font-1", 0, supplier);
+        Font second = FontCache.get("font-2", 0, supplier);
+
+        assertNotSame(first, second);
+        assertEquals(2, created.get());
+    }
+
+    @Test
+    public void testFontWithoutKeyIsNotCached() {
+        Font first = FontCache.get(null, 0, supplier);
+        Font second = FontCache.get(null, 0, supplier);
+
+        assertNotSame(first, second);
+        assertEquals(2, created.get());
+        assertEquals(0, FontCache.size());
+    }
+
+    @Test
+    public void testFontIsRecreatedWhenResourceChanged() {
+        Font first = FontCache.get("font-1", 1000, supplier);
+        Font second = FontCache.get("font-1", 1000, supplier);
+        Font third = FontCache.get("font-1", 2000, supplier);
+
+        assertSame(first, second);
+        assertNotSame(second, third);
+        assertEquals(2, created.get());
+
+        // The stale font is replaced rather than kept beside the new one.
+        assertEquals(1, FontCache.size());
+    }
+
+    @Test
+    public void testFailureToCreateFontIsNotCached() {
+        Font first = FontCache.get("font-1", 0, () -> null);
+
+        assertNull(first);
+        assertEquals(0, FontCache.size());
+
+        // So that a font that was temporarily unavailable can still be loaded later.
+        assertSame(FontCache.get("font-1", 0, supplier), FontCache.get("font-1", 0, supplier));
+        assertEquals(1, created.get());
+    }
+
+    @Test
+    public void testInvalidateAllDropsCachedFonts() {
+        Font first = FontCache.get("font-1", 0, supplier);
+        FontCache.invalidateAll();
+        Font second = FontCache.get("font-1", 0, supplier);
+
+        assertNotSame(first, second);
+        assertEquals(2, created.get());
+    }
+
+    @Test
+    public void testKeyAndLastModifiedAreTakenFromSupplier() {
+        class KeyedSupplier implements FSSupplier<Font> {
+            private long lastModified;
+
+            @Override
+            public Font supply() {
+                return supplier.supply();
+            }
+
+            @Override
+            public String cacheKey() {
+                return "font-1";
+            }
+
+            @Override
+            public long lastModified() {
+                return lastModified;
+            }
+        }
+
+        KeyedSupplier keyed = new KeyedSupplier();
+
+        Font first = FontCache.get(keyed);
+        Font second = FontCache.get(keyed);
+
+        assertSame(first, second);
+        assertEquals(1, created.get());
+
+        keyed.lastModified = 1000;
+
+        assertNotSame(second, FontCache.get(keyed));
+        assertEquals(2, created.get());
+    }
+
+    @Test
+    public void testSupplierIsNotCacheableByDefault() {
+        FSSupplier<InputStream> plain = () -> null;
+
+        assertNull(plain.cacheKey());
+        assertEquals(FSSupplier.UNKNOWN_LAST_MODIFIED, plain.lastModified());
+    }
+
+    @Test
+    public void testContentCacheKeyFollowsContent() {
+        byte[] content = "a font".getBytes(StandardCharsets.UTF_8);
+
+        assertEquals(FontCache.contentCacheKey(content), FontCache.contentCacheKey(content.clone()));
+        assertNotEquals(FontCache.contentCacheKey(content),
+                FontCache.contentCacheKey("another font".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * The point of the cache: concurrent renders of the same document must not each register
+     * their own copy of the font with the JDK.
+     */
+    @Test
+    public void testFontIsCreatedOnceWhenThreadsRace() throws InterruptedException {
+        int threads = 8;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.execute(() -> {
+                    try {
+                        start.await();
+                        FontCache.get("font-1", 0, supplier);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals(1, created.get());
+    }
+}

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplierTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/outputdevice/helper/FontFaceFontSupplierTest.java
@@ -1,0 +1,74 @@
+package com.openhtmltopdf.outputdevice.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.resource.ImageResource;
+import com.openhtmltopdf.swing.NaiveUserAgent;
+
+public class FontFaceFontSupplierTest {
+    private static SharedContext context(String baseUri) {
+        NaiveUserAgent uac = new NaiveUserAgent() {
+            @Override
+            public ImageResource getImageResource(String uri, ExternalResourceType type) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        uac.setBaseURL(baseUri);
+
+        SharedContext ctx = new SharedContext();
+        ctx.setUserAgentCallback(uac);
+
+        return ctx;
+    }
+
+    private static String cacheKey(String baseUri, String src) {
+        return new FontFaceFontSupplier(context(baseUri), src).cacheKey();
+    }
+
+    /**
+     * The same relative src in two documents usually refers to two different fonts.
+     */
+    @Test
+    public void testRelativeSrcIsResolvedAgainstBaseUri() {
+        String one = cacheKey("file:/documents/one/index.html", "font.ttf");
+        String two = cacheKey("file:/documents/two/index.html", "font.ttf");
+
+        assertEquals("file:/documents/one/font.ttf", one);
+        assertEquals("file:/documents/two/font.ttf", two);
+        assertNotEquals(one, two);
+    }
+
+    @Test
+    public void testAbsoluteSrcIsUsedAsIs() {
+        assertEquals("http://example.com/font.ttf",
+                cacheKey("file:/documents/one/index.html", "http://example.com/font.ttf"));
+    }
+
+    /**
+     * Without a base URI we can not tell which font a relative src refers to, so it must not be
+     * cached at all.
+     */
+    @Test
+    public void testUnresolvableSrcIsNotCacheable() {
+        assertNull(cacheKey(null, "font.ttf"));
+    }
+
+    /**
+     * A data URI already identifies the font by its content, but is far too long to hold on to.
+     */
+    @Test
+    public void testDataSrcIsKeyedOnItsHash() {
+        String src = "data:font/ttf;base64,AAEAAAALAIAAAwAwT1MvMg8SBfoAAAC8AAAAYGNtYXA";
+        String key = cacheKey("file:/documents/one/index.html", src);
+
+        assertEquals(FontCache.contentCacheKey(src.getBytes(StandardCharsets.UTF_8)), key);
+        assertNotEquals(key, cacheKey("file:/documents/one/index.html", src + "XYZ"));
+    }
+}

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/FontCacheNonVisualTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/FontCacheNonVisualTest.java
@@ -1,0 +1,150 @@
+package com.openhtmltopdf.nonvisualregressiontests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import org.apache.pdfbox.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.openhtmltopdf.extend.FSSupplier;
+import com.openhtmltopdf.outputdevice.helper.FontCache;
+
+/**
+ * Tests {@link FontCache} with real true type fonts. Every {@code Font.createFont} call registers
+ * a font with the JDK font manager that is never released, see
+ * <a href="https://bugs.openjdk.org/browse/JDK-8239833">JDK-8239833</a>, so repeated renders of
+ * the same document have to end up with the very same font instance.
+ */
+public class FontCacheNonVisualTest {
+    private static final String KARLA = "/visualtest/html/fonts/Karla-Bold.ttf";
+    private static final String SOURCE_SANS = "/visualtest/html/fonts/SourceSansPro-Regular.ttf";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void emptyCache() {
+        FontCache.invalidateAll();
+    }
+
+    private static byte[] font(String resource) throws IOException {
+        try (InputStream is = FontCacheNonVisualTest.class.getResourceAsStream(resource)) {
+            return IOUtils.toByteArray(is);
+        }
+    }
+
+    private File fontFile(String name, String resource) throws IOException {
+        File file = folder.newFile(name);
+        Files.write(file.toPath(), font(resource));
+        return file;
+    }
+
+    @Test
+    public void testBytesAreKeyedOnTheirContent() throws IOException, FontFormatException {
+        byte[] karla = font(KARLA);
+
+        Font first = FontCache.getTrueTypeFont(karla);
+        Font second = FontCache.getTrueTypeFont(karla.clone());
+
+        assertSame(first, second);
+        assertNotSame(first, FontCache.getTrueTypeFont(font(SOURCE_SANS)));
+    }
+
+    @Test
+    public void testFileIsKeyedOnItsPath() throws IOException, FontFormatException {
+        File file = fontFile("font.ttf", KARLA);
+
+        Font first = FontCache.getTrueTypeFont(file);
+        Font second = FontCache.getTrueTypeFont(new File(file.getAbsolutePath()));
+
+        assertSame(first, second);
+        assertEquals("Karla", first.getFamily());
+    }
+
+    /**
+     * A font file that is replaced on disk has to be picked up again, otherwise a long running
+     * application would serve the old font forever.
+     */
+    @Test
+    public void testChangedFileIsReloaded() throws IOException, FontFormatException {
+        File file = fontFile("font.ttf", KARLA);
+
+        Font first = FontCache.getTrueTypeFont(file);
+        Files.write(file.toPath(), font(SOURCE_SANS));
+        Font second = FontCache.getTrueTypeFont(file);
+
+        assertNotSame(first, second);
+        assertEquals("Karla", first.getFamily());
+        assertEquals("Source Sans Pro", second.getFamily());
+    }
+
+    @Test
+    public void testStreamIsKeyedOnSupplierCacheKey() throws IOException, FontFormatException {
+        class KarlaSupplier implements FSSupplier<InputStream> {
+            private int supplied;
+
+            @Override
+            public InputStream supply() {
+                supplied++;
+                try {
+                    return new ByteArrayInputStream(font(KARLA));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public String cacheKey() {
+                return "http://example.com/Karla-Bold.ttf";
+            }
+        }
+
+        KarlaSupplier supplier = new KarlaSupplier();
+
+        assertSame(FontCache.getTrueTypeFont(supplier), FontCache.getTrueTypeFont(supplier));
+        assertEquals(1, supplier.supplied);
+    }
+
+    /**
+     * Fonts from a supplier that can not identify itself - a user provided lambda, for example -
+     * still have to work, they just can not be cached.
+     */
+    @Test
+    public void testStreamWithoutCacheKeyIsNotCached() throws IOException, FontFormatException {
+        byte[] karla = font(KARLA);
+        FSSupplier<InputStream> supplier = () -> new ByteArrayInputStream(karla);
+
+        assertNull(supplier.cacheKey());
+        assertNotSame(FontCache.getTrueTypeFont(supplier), FontCache.getTrueTypeFont(supplier));
+    }
+
+    @Test
+    public void testMissingFontIsNotSupplied() throws IOException, FontFormatException {
+        FSSupplier<InputStream> supplier = new FSSupplier<InputStream>() {
+            @Override
+            public InputStream supply() {
+                return null;
+            }
+
+            @Override
+            public String cacheKey() {
+                return "http://example.com/missing.ttf";
+            }
+        };
+
+        assertNull(FontCache.getTrueTypeFont(supplier));
+    }
+}

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 /**
@@ -55,6 +56,14 @@ import java.util.logging.Level;
  * @author Joshua Marinacci
  */
 public class Java2DFontResolver implements FontResolver {
+
+    /**
+     * Cache of Font objects created via Font.createFont(). Each call to
+     * Font.createFont() registers a new TrueTypeFont in the JDK's
+     * SunFontManager that is never released, so fonts must be cached
+     * to avoid a memory leak when rendering repeatedly.
+     */
+    private static final ConcurrentHashMap<String, Font> fontCache = new ConcurrentHashMap<>();
 
     private static abstract class FontDescription implements MinimalFontDescription {
         //protected static final String FAIL_MSG = "Couldn't load font. Please check that it is a valid truetype font.";
@@ -86,31 +95,46 @@ public class Java2DFontResolver implements FontResolver {
 
     private static class InputStreamFontDescription extends FontDescription {
         private FSSupplier<InputStream> _supplier;
+        private final String _cacheKey;
 
-        private InputStreamFontDescription(FSSupplier<InputStream> supplier, int weight, IdentValue style) {
+        private InputStreamFontDescription(FSSupplier<InputStream> supplier, int weight, IdentValue style, String cacheKey) {
             super(weight, style);
             this._supplier = supplier;
+            this._cacheKey = cacheKey;
         }
-        
+
         @Override
         protected boolean realizeFont() {
-            if (_font == null && _supplier != null) {
-                InputStream is = _supplier.supply();
-                _supplier = null; // We only try once.
-
-                if (is == null) {
-                    return false;
+            if (_font == null) {
+                if (_cacheKey != null) {
+                    _font = fontCache.get(_cacheKey);
+                    if (_font != null) {
+                        _supplier = null;
+                        return true;
+                    }
                 }
 
-                try {
-                    _font = Font.createFont(Font.TRUETYPE_FONT, is);
-                } catch (IOException|FontFormatException e) {
-                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
-                    return false;
-                } finally {
+                if (_supplier != null) {
+                    InputStream is = _supplier.supply();
+                    _supplier = null; // We only try once.
+
+                    if (is == null) {
+                        return false;
+                    }
+
                     try {
-                        is.close();
-                    } catch (IOException e) {
+                        _font = Font.createFont(Font.TRUETYPE_FONT, is);
+                        if (_cacheKey != null) {
+                            fontCache.put(_cacheKey, _font);
+                        }
+                    } catch (IOException|FontFormatException e) {
+                        XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
+                        return false;
+                    } finally {
+                        try {
+                            is.close();
+                        } catch (IOException e) {
+                        }
                     }
                 }
             }
@@ -121,17 +145,30 @@ public class Java2DFontResolver implements FontResolver {
     
     private static class FileFontDescription extends FontDescription {
         private File _fontFile;
+        private final boolean _useCache;
 
-        private FileFontDescription(File fontFile, int weight, IdentValue style) {
+        private FileFontDescription(File fontFile, int weight, IdentValue style, boolean useCache) {
             super(weight, style);
             this._fontFile = fontFile;
+            this._useCache = useCache;
         }
-        
+
         @Override
         protected boolean realizeFont() {
             if (_font == null && _fontFile != null) {
+                if (_useCache) {
+                    String path = _fontFile.getAbsolutePath();
+                    _font = fontCache.get(path);
+                    if (_font != null) {
+                        _fontFile = null;
+                        return true;
+                    }
+                }
                 try {
                     _font = Font.createFont(Font.TRUETYPE_FONT, _fontFile);
+                    if (_useCache) {
+                        fontCache.put(_fontFile.getAbsolutePath(), _font);
+                    }
                     _fontFile = null;
                 } catch (IOException | FontFormatException e) {
                     XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
@@ -157,13 +194,19 @@ public class Java2DFontResolver implements FontResolver {
     private final Map<String, Font> availableFontsHash = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     private final SharedContext _sharedContext;
+    private final boolean _cacheFonts;
 
     // Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
     // section 5.1: https://www.w3.org/TR/css-fonts-3/#font-family-casing).
     private final Map<String, FontFamily<FontDescription>> _fontFamilies = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    
+
     public Java2DFontResolver(SharedContext sharedCtx, boolean useEnvironmentFonts) {
+        this(sharedCtx, useEnvironmentFonts, true);
+    }
+
+    public Java2DFontResolver(SharedContext sharedCtx, boolean useEnvironmentFonts, boolean cacheFonts) {
         _sharedContext = sharedCtx;
+        _cacheFonts = cacheFonts;
         if (useEnvironmentFonts) {
             init();
         }
@@ -229,27 +272,34 @@ public class Java2DFontResolver implements FontResolver {
     
     public void addInputStreamFont(FSSupplier<InputStream> fontSupplier, String fontFamilyNameOverride,
             Integer fontWeightOverride, IdentValue fontStyleOverride) {
-        
+        addInputStreamFont(fontSupplier, fontFamilyNameOverride, fontWeightOverride, fontStyleOverride, null);
+    }
+
+    private void addInputStreamFont(FSSupplier<InputStream> fontSupplier, String fontFamilyNameOverride,
+            Integer fontWeightOverride, IdentValue fontStyleOverride, String cacheKey) {
+
         FontFamily<FontDescription> fontFamily = getFontFamily(fontFamilyNameOverride);
-        
+
         FontDescription descr = new InputStreamFontDescription(
                 fontSupplier,
                 fontWeightOverride != null ? fontWeightOverride : 400,
-                fontStyleOverride != null ? fontStyleOverride : IdentValue.NORMAL); 
+                fontStyleOverride != null ? fontStyleOverride : IdentValue.NORMAL,
+                cacheKey);
 
        fontFamily.addFontDescription(descr);
     }
-    
+
     private void addFontFaceFont(
             String fontFamilyNameOverride, IdentValue fontWeightOverride, IdentValue fontStyleOverride,
             String uri) {
-        
+
         FSSupplier<InputStream> fontSupplier = new FontFaceFontSupplier(_sharedContext, uri);
         addInputStreamFont(
                 fontSupplier,
                 fontFamilyNameOverride,
-                fontWeightOverride != null ? FontResolverHelper.convertWeightToInt(fontWeightOverride) : 400, 
-                fontStyleOverride);
+                fontWeightOverride != null ? FontResolverHelper.convertWeightToInt(fontWeightOverride) : 400,
+                fontStyleOverride,
+                _cacheFonts ? uri : null);
     }
     
     /**
@@ -263,7 +313,8 @@ public class Java2DFontResolver implements FontResolver {
         FontDescription descr = new FileFontDescription(
                 fontFile,
                 fontWeightOverride != null ? fontWeightOverride : 400,
-                fontStyleOverride != null ? fontStyleOverride : IdentValue.NORMAL); 
+                fontStyleOverride != null ? fontStyleOverride : IdentValue.NORMAL,
+                _cacheFonts);
 
         fontFamily.addFontDescription(descr);
     }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DFontResolver.java
@@ -28,6 +28,7 @@ import com.openhtmltopdf.css.value.FontSpecification;
 import com.openhtmltopdf.extend.FSSupplier;
 import com.openhtmltopdf.extend.FontResolver;
 import com.openhtmltopdf.layout.SharedContext;
+import com.openhtmltopdf.outputdevice.helper.FontCache;
 import com.openhtmltopdf.outputdevice.helper.FontFaceFontSupplier;
 import com.openhtmltopdf.outputdevice.helper.FontFamily;
 import com.openhtmltopdf.outputdevice.helper.FontResolverHelper;
@@ -47,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 /**
@@ -56,14 +56,6 @@ import java.util.logging.Level;
  * @author Joshua Marinacci
  */
 public class Java2DFontResolver implements FontResolver {
-
-    /**
-     * Cache of Font objects created via Font.createFont(). Each call to
-     * Font.createFont() registers a new TrueTypeFont in the JDK's
-     * SunFontManager that is never released, so fonts must be cached
-     * to avoid a memory leak when rendering repeatedly.
-     */
-    private static final ConcurrentHashMap<String, Font> fontCache = new ConcurrentHashMap<>();
 
     private static abstract class FontDescription implements MinimalFontDescription {
         //protected static final String FAIL_MSG = "Couldn't load font. Please check that it is a valid truetype font.";
@@ -95,80 +87,52 @@ public class Java2DFontResolver implements FontResolver {
 
     private static class InputStreamFontDescription extends FontDescription {
         private FSSupplier<InputStream> _supplier;
-        private final String _cacheKey;
+        private final boolean _cacheFonts;
 
-        private InputStreamFontDescription(FSSupplier<InputStream> supplier, int weight, IdentValue style, String cacheKey) {
+        private InputStreamFontDescription(FSSupplier<InputStream> supplier, int weight, IdentValue style, boolean cacheFonts) {
             super(weight, style);
             this._supplier = supplier;
-            this._cacheKey = cacheKey;
+            this._cacheFonts = cacheFonts;
         }
 
         @Override
         protected boolean realizeFont() {
-            if (_font == null) {
-                if (_cacheKey != null) {
-                    _font = fontCache.get(_cacheKey);
-                    if (_font != null) {
-                        _supplier = null;
-                        return true;
-                    }
-                }
+            if (_font == null && _supplier != null) {
+                FSSupplier<InputStream> supplier = _supplier;
+                _supplier = null; // We only try once.
 
-                if (_supplier != null) {
-                    InputStream is = _supplier.supply();
-                    _supplier = null; // We only try once.
-
-                    if (is == null) {
-                        return false;
-                    }
-
-                    try {
-                        _font = Font.createFont(Font.TRUETYPE_FONT, is);
-                        if (_cacheKey != null) {
-                            fontCache.put(_cacheKey, _font);
-                        }
-                    } catch (IOException|FontFormatException e) {
-                        XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
-                        return false;
-                    } finally {
-                        try {
-                            is.close();
-                        } catch (IOException e) {
-                        }
-                    }
+                try {
+                    // Suppliers that can not identify their font have a null cache key, in which
+                    // case the font is created without being cached.
+                    _font = FontCache.getTrueTypeFont(
+                            _cacheFonts ? supplier.cacheKey() : null, supplier.lastModified(), supplier);
+                } catch (IOException|FontFormatException e) {
+                    XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
+                    return false;
                 }
             }
 
             return _font != null;
         }
     }
-    
+
     private static class FileFontDescription extends FontDescription {
         private File _fontFile;
-        private final boolean _useCache;
+        private final boolean _cacheFonts;
 
-        private FileFontDescription(File fontFile, int weight, IdentValue style, boolean useCache) {
+        private FileFontDescription(File fontFile, int weight, IdentValue style, boolean cacheFonts) {
             super(weight, style);
             this._fontFile = fontFile;
-            this._useCache = useCache;
+            this._cacheFonts = cacheFonts;
         }
 
         @Override
         protected boolean realizeFont() {
             if (_font == null && _fontFile != null) {
-                if (_useCache) {
-                    String path = _fontFile.getAbsolutePath();
-                    _font = fontCache.get(path);
-                    if (_font != null) {
-                        _fontFile = null;
-                        return true;
-                    }
-                }
                 try {
-                    _font = Font.createFont(Font.TRUETYPE_FONT, _fontFile);
-                    if (_useCache) {
-                        fontCache.put(_fontFile.getAbsolutePath(), _font);
-                    }
+                    _font = _cacheFonts ?
+                            FontCache.getTrueTypeFont(_fontFile) :
+                            Font.createFont(Font.TRUETYPE_FONT, _fontFile);
                     _fontFile = null;
                 } catch (IOException | FontFormatException e) {
                     XRLog.log(Level.WARNING, LogMessageId.LogMessageId0Param.EXCEPTION_JAVA2D_COULD_NOT_LOAD_FONT, e);
@@ -194,6 +158,7 @@ public class Java2DFontResolver implements FontResolver {
     private final Map<String, Font> availableFontsHash = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     private final SharedContext _sharedContext;
+
     private final boolean _cacheFonts;
 
     // Family-name lookup is case-insensitive per the CSS spec (CSS Fonts Level 3,
@@ -204,6 +169,10 @@ public class Java2DFontResolver implements FontResolver {
         this(sharedCtx, useEnvironmentFonts, true);
     }
 
+    /**
+     * @param cacheFonts whether fonts may be taken from and put into the process wide
+     * {@link FontCache}. See {@code Java2DRendererBuilder#cacheFonts(boolean)}.
+     */
     public Java2DFontResolver(SharedContext sharedCtx, boolean useEnvironmentFonts, boolean cacheFonts) {
         _sharedContext = sharedCtx;
         _cacheFonts = cacheFonts;
@@ -272,34 +241,28 @@ public class Java2DFontResolver implements FontResolver {
     
     public void addInputStreamFont(FSSupplier<InputStream> fontSupplier, String fontFamilyNameOverride,
             Integer fontWeightOverride, IdentValue fontStyleOverride) {
-        addInputStreamFont(fontSupplier, fontFamilyNameOverride, fontWeightOverride, fontStyleOverride, null);
-    }
-
-    private void addInputStreamFont(FSSupplier<InputStream> fontSupplier, String fontFamilyNameOverride,
-            Integer fontWeightOverride, IdentValue fontStyleOverride, String cacheKey) {
-
+        
         FontFamily<FontDescription> fontFamily = getFontFamily(fontFamilyNameOverride);
-
+        
         FontDescription descr = new InputStreamFontDescription(
                 fontSupplier,
                 fontWeightOverride != null ? fontWeightOverride : 400,
                 fontStyleOverride != null ? fontStyleOverride : IdentValue.NORMAL,
-                cacheKey);
+                _cacheFonts);
 
        fontFamily.addFontDescription(descr);
     }
-
+    
     private void addFontFaceFont(
             String fontFamilyNameOverride, IdentValue fontWeightOverride, IdentValue fontStyleOverride,
             String uri) {
-
+        
         FSSupplier<InputStream> fontSupplier = new FontFaceFontSupplier(_sharedContext, uri);
         addInputStreamFont(
                 fontSupplier,
                 fontFamilyNameOverride,
-                fontWeightOverride != null ? FontResolverHelper.convertWeightToInt(fontWeightOverride) : 400,
-                fontStyleOverride,
-                _cacheFonts ? uri : null);
+                fontWeightOverride != null ? FontResolverHelper.convertWeightToInt(fontWeightOverride) : 400, 
+                fontStyleOverride);
     }
     
     /**

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/Java2DRenderer.java
@@ -115,7 +115,7 @@ public class Java2DRenderer implements Closeable {
 //        uac.setSharedContext(_sharedContext);
 //        _outputDevice.setSharedContext(_sharedContext);
 
-        Java2DFontResolver fontResolver = new Java2DFontResolver(_sharedContext, state._useEnvironmentFonts);
+        Java2DFontResolver fontResolver = new Java2DFontResolver(_sharedContext, state._useEnvironmentFonts, state._cacheFonts);
         _sharedContext.setFontResolver(fontResolver);
         
         /*

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/DefaultPageProcessor.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/DefaultPageProcessor.java
@@ -94,5 +94,6 @@ public class DefaultPageProcessor implements FSPageProcessor {
 		DefaultPage page = (DefaultPage) pg;
 		page.getGraphics().dispose();
 		page.save();
+		page._img.flush();
 	}
 }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/DefaultPageProcessor.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/DefaultPageProcessor.java
@@ -45,6 +45,14 @@ public class DefaultPageProcessor implements FSPageProcessor {
 			return _g2d;
 		}
 		
+		/**
+		 * Releases the native resources behind the page image. Only call this once the page has
+		 * been saved, as the image is unusable afterwards.
+		 */
+		public void flush() {
+			_img.flush();
+		}
+
 		public void save() {
 			OutputStream os = null;
 			try {
@@ -94,6 +102,6 @@ public class DefaultPageProcessor implements FSPageProcessor {
 		DefaultPage page = (DefaultPage) pg;
 		page.getGraphics().dispose();
 		page.save();
-		page._img.flush();
+		page.flush();
 	}
 }

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -47,11 +47,15 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
     }
 
 	/**
-	 * Whether to cache fonts loaded via {@code @font-face} CSS rules and
-	 * {@link #useFont} across renders. Caching avoids repeated calls to
-	 * {@link java.awt.Font#createFont} which registers a new TrueTypeFont
-	 * in the JDK's SunFontManager on each call, leaking memory.
-	 * Enabled by default. Disable if fonts change between renders.
+	 * Whether fonts used by this renderer may be taken from and put into the process wide
+	 * {@link com.openhtmltopdf.outputdevice.helper.FontCache}. Caching is on by default and
+	 * avoids leaking memory, as every font created with {@link Font#createFont(int, java.io.File)}
+	 * stays registered with the JDK font manager forever.
+	 *
+	 * <p>Fonts added with {@link #useFont(java.io.File, String)} are reloaded when the file
+	 * changes, so caching only has to be turned off for fonts whose content changes behind a
+	 * stable URI. {@link com.openhtmltopdf.outputdevice.helper.FontCache#invalidateAll()} can be
+	 * used to drop such fonts instead.</p>
 	 */
 	public Java2DRendererBuilder cacheFonts(boolean cacheFonts) {
 		state._cacheFonts = cacheFonts;

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilder.java
@@ -47,6 +47,18 @@ public class Java2DRendererBuilder extends BaseRendererBuilder<Java2DRendererBui
     }
 
 	/**
+	 * Whether to cache fonts loaded via {@code @font-face} CSS rules and
+	 * {@link #useFont} across renders. Caching avoids repeated calls to
+	 * {@link java.awt.Font#createFont} which registers a new TrueTypeFont
+	 * in the JDK's SunFontManager on each call, leaking memory.
+	 * Enabled by default. Disable if fonts change between renders.
+	 */
+	public Java2DRendererBuilder cacheFonts(boolean cacheFonts) {
+		state._cacheFonts = cacheFonts;
+		return this;
+	}
+
+	/**
 	 * Render everything to a single page. I.e. only one big page is genereated, no
 	 * pagebreak will be done. The page is only as height as needed.
 	 */

--- a/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
+++ b/openhtmltopdf-java2d/src/main/java/com/openhtmltopdf/java2d/api/Java2DRendererBuilderState.java
@@ -16,4 +16,5 @@ public class Java2DRendererBuilderState extends BaseRendererBuilder.BaseRenderer
 	public Graphics2D _layoutGraphics;
 	public FSPageProcessor _pageProcessor;
     public boolean _useEnvironmentFonts = false;
+    public boolean _cacheFonts = true;
 }

--- a/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlGvtFont.java
+++ b/openhtmltopdf-svg-support/src/main/java/com/openhtmltopdf/svgsupport/OpenHtmlGvtFont.java
@@ -4,12 +4,12 @@ import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextAttribute;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.text.CharacterIterator;
 import java.util.logging.Level;
 
+import com.openhtmltopdf.outputdevice.helper.FontCache;
 import com.openhtmltopdf.util.LogMessageId;
 import com.openhtmltopdf.util.XRLog;
 import org.apache.batik.gvt.font.GVTFont;
@@ -46,7 +46,7 @@ public class OpenHtmlGvtFont implements GVTFont {
     }
 
     public OpenHtmlGvtFont(File fontFile, GVTFontFamily family, float size, Float fontWeight, Float fontStyle) throws IOException, FontFormatException {
-        Font font = Font.createFont(Font.TRUETYPE_FONT, fontFile);
+        Font font = FontCache.getTrueTypeFont(fontFile);
 
         this.baseFont = font;
         this.fontFamily = family;
@@ -54,9 +54,9 @@ public class OpenHtmlGvtFont implements GVTFont {
 
 	public OpenHtmlGvtFont(byte[] fontBytes, GVTFontFamily family, float size, Float fontWeight, Float fontStyle) throws FontFormatException {
 		Font font;
-		
+
 		try {
-			font = Font.createFont(Font.TRUETYPE_FONT, new ByteArrayInputStream(fontBytes)).deriveFont(toFontWeight(fontWeight) | toStyle(fontStyle) , size);
+			font = FontCache.getTrueTypeFont(fontBytes).deriveFont(toFontWeight(fontWeight) | toStyle(fontStyle) , size);
 		} catch (IOException e) {
 			// Shouldn't happen
 			XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_SVG_CREATE_FONT, family != null ? family.getFamilyName() : "", e);


### PR DESCRIPTION
Hi, we just tracked down a severe memory leak related to using TTF fonts with openhtmltopdf, because the JDK leaks those fonts: once you create a font it stays in memory forever. It also creates a lot of /tmp files. See https://bugs.openjdk.org/browse/JDK-8239833 for one report of the bug (they did not really fix it), but there's a further leak related to caching font strikes that never expire. Getting a fix in the JDK takes forever, so I figured it would be easier to work around it in openhtmltopdf.

I have a similar fix locally that doesn't require changes to openhtmltopdf, but I figured this would be useful for most people.

Each call to Font.createFont() registers a new TrueTypeFont in the JDK's SunFontManager that is never released. When @font-face CSS rules are used, importFontFaces() calls Font.createFont() on every render, leaking ~5 MB per render. This causes OutOfMemoryError in long-running applications, especially in GraalVM native image with smaller heaps.

Fix by caching Font objects in a static ConcurrentHashMap keyed by font URI (for @font-face) or file path (for file-based fonts). The cache is enabled by default and can be disabled via cacheFonts(false) on the Java2DRendererBuilder for cases where fonts change between renders.

Also flush the BufferedImage in DefaultPageProcessor.finishPage() to eagerly release native AWT surface resources after each page is saved.