### PR TITLE
Fix #176: fast-reject non-matching selectors in Mapper.mapChild

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
@@ -229,6 +229,38 @@ public class Matcher {
         _map.put(e, m);
     }
 
+    /**
+     * Class attribute split into whitespace-delimited tokens (same semantics as
+     * ClassCondition); null when the attribute is absent.
+     */
+    static Set<String> classTokens(String classAttr) {
+        if (classAttr == null) {
+            return null;
+        }
+
+        Set<String> result = Collections.emptySet();
+        int length = classAttr.length();
+        int i = 0;
+
+        while (i < length) {
+            while (i < length && Character.isWhitespace(classAttr.charAt(i))) {
+                i++;
+            }
+            int start = i;
+            while (i < length && !Character.isWhitespace(classAttr.charAt(i))) {
+                i++;
+            }
+            if (i > start) {
+                if (result.isEmpty()) {
+                    result = new HashSet<>(8);
+                }
+                result.add(classAttr.substring(start, i));
+            }
+        }
+
+        return result;
+    }
+
     private Mapper getMapper(Object e) {
         Mapper m = _map.get(e);
         if (m != null) {
@@ -312,6 +344,11 @@ public class Matcher {
 
             StringBuilder key = new StringBuilder();
 
+            // Read once per element and reused by Selector.mayMatch for every candidate selector.
+            String elementName = _treeRes.getElementName(e);
+            String elementId = _attRes != null ? _attRes.getID(e) : null;
+            Set<String> elementClasses = classTokens(_attRes != null ? _attRes.getClass(e) : null);
+
             for (Selector sel : axes) {
                 if (sel.getAxis() == Selector.DESCENDANT_AXIS) {
                     if (childAxes == null) {
@@ -322,6 +359,10 @@ public class Matcher {
                     childAxes.add(sel);
                 } else if (sel.getAxis() == Selector.IMMEDIATE_SIBLING_AXIS) {
                     throw new RuntimeException();
+                }
+
+                if (!sel.mayMatch(elementName, elementId, elementClasses)) {
+                    continue;
                 }
 
                 if (!sel.matches(e, _attRes, _treeRes)) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
@@ -56,6 +56,10 @@ public class Selector {
 
     private List<Condition> conditions;
 
+    /** Rightmost simple-selector requirements, recorded at parse time for {@link #mayMatch}. */
+    private String _requiredId;
+    private List<String> _requiredClasses;
+
     public final static int DESCENDANT_AXIS = 0;
     public final static int CHILD_AXIS = 1;
     public final static int IMMEDIATE_SIBLING_AXIS = 2;
@@ -103,6 +107,32 @@ public class Selector {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Conservative fast pre-check for {@link #matches}: returns false only when
+     * matches() certainly would, so Matcher.Mapper can skip the full match for
+     * most candidate selectors. {@code classes} are the element's class tokens
+     * (null if none); the namespace check is left to matches().
+     */
+    boolean mayMatch(String elementName, String id, Set<String> classes) {
+        if (_name != null && !_name.equals(elementName)) {
+            return false;
+        }
+        if (_requiredId != null && !_requiredId.equals(id)) {
+            return false;
+        }
+        if (_requiredClasses != null) {
+            if (classes == null) {
+                return false;
+            }
+            for (int i = 0; i < _requiredClasses.size(); i++) {
+                if (!classes.contains(_requiredClasses.get(i))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**
@@ -216,6 +246,9 @@ public class Selector {
     public void addIDCondition(String id) {
         _specificityB++;
         addCondition(Condition.createIDCondition(id));
+        if (_requiredId == null) {
+            _requiredId = id;
+        }
     }
 
     /**
@@ -224,6 +257,10 @@ public class Selector {
     public void addClassCondition(String className) {
         _specificityC++;
         addCondition(Condition.createClassCondition(className));
+        if (_requiredClasses == null) {
+            _requiredClasses = new java.util.ArrayList<>(2);
+        }
+        _requiredClasses.add(className);
     }
 
     /**

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/newmatch/SelectorMayMatchTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/newmatch/SelectorMayMatchTest.java
@@ -1,0 +1,125 @@
+package com.openhtmltopdf.css.newmatch;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.openhtmltopdf.css.extend.AttributeResolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests that {@link Selector#mayMatch} is a sound fast-reject for
+ * {@link Selector#matches}: it must never return false for an element the
+ * full match would accept (it may return true for elements the full match
+ * rejects; those are filtered by the full match).
+ */
+public class SelectorMayMatchTest {
+
+    private static final Object ANY_ELEMENT = new Object();
+
+    @Test
+    public void rejectsOnElementName() {
+        Selector sel = new Selector();
+        sel.setName("div");
+        assertTrue(sel.mayMatch("div", null, null));
+        assertFalse(sel.mayMatch("span", null, null));
+        assertFalse(sel.mayMatch(null, null, null));
+    }
+
+    @Test
+    public void doesNotRejectWithoutNameRequirement() {
+        Selector sel = new Selector();
+        assertTrue(sel.mayMatch("div", null, null));
+        assertTrue(sel.mayMatch(null, null, null));
+    }
+
+    @Test
+    public void rejectsOnId() {
+        Selector sel = new Selector();
+        sel.addIDCondition("x");
+        assertTrue(sel.mayMatch(null, "x", null));
+        assertFalse(sel.mayMatch(null, "y", null));
+        assertFalse(sel.mayMatch(null, null, null));
+    }
+
+    @Test
+    public void rejectsOnMissingClasses() {
+        Selector sel = new Selector();
+        sel.addClassCondition("a");
+        sel.addClassCondition("b");
+
+        assertTrue(sel.mayMatch(null, null, Matcher.classTokens("b c a")));
+        assertFalse(sel.mayMatch(null, null, Matcher.classTokens("a c")));
+        // No class attribute at all
+        assertFalse(sel.mayMatch(null, null, null));
+        // Empty class attribute
+        assertFalse(sel.mayMatch(null, null, Matcher.classTokens("  ")));
+    }
+
+    @Test
+    public void classTokensSplitsOnAnyWhitespace() {
+        Set<String> tokens = Matcher.classTokens("a\tb\nc  d ");
+        assertEquals(4, tokens.size());
+        assertTrue(tokens.contains("a"));
+        assertTrue(tokens.contains("b"));
+        assertTrue(tokens.contains("c"));
+        assertTrue(tokens.contains("d"));
+
+        assertNull(Matcher.classTokens(null));
+        assertTrue(Matcher.classTokens("").isEmpty());
+        assertTrue(Matcher.classTokens(" \t").isEmpty());
+    }
+
+    /**
+     * The class part of mayMatch must agree exactly with ClassCondition,
+     * including the substring-prefix collision cases of
+     * https://github.com/openhtmltopdf/openhtmltopdf/issues/171.
+     */
+    @Test
+    public void classRejectionAgreesWithClassCondition() {
+        String[] classAttrs = {"alpha a b", "a b", "alpha", "ab a", "a", "aa", " a ", "b  a"};
+        String[] classNames = {"a", "b", "alpha", "ab", "aa"};
+
+        for (String classAttr : classAttrs) {
+            Set<String> tokens = Matcher.classTokens(classAttr);
+            AttributeResolver attRes = new ClassOnlyAttributeResolver(classAttr);
+
+            for (String className : classNames) {
+                Selector sel = new Selector();
+                sel.addClassCondition(className);
+
+                boolean full = Condition.createClassCondition(className)
+                        .matches(ANY_ELEMENT, attRes, null);
+                boolean fast = sel.mayMatch(null, null, tokens);
+
+                assertEquals("class=\"" + classAttr + "\" vs ." + className, full, fast);
+            }
+        }
+    }
+
+    private static final class ClassOnlyAttributeResolver implements AttributeResolver {
+        private final String classValue;
+
+        ClassOnlyAttributeResolver(String classValue) {
+            this.classValue = classValue;
+        }
+
+        @Override public String getClass(Object e) { return classValue; }
+        @Override public String getAttributeValue(Object e, String attrName) { return null; }
+        @Override public String getAttributeValue(Object e, String namespaceURI, String attrName) { return null; }
+        @Override public String getID(Object e) { return null; }
+        @Override public String getNonCssStyling(Object e) { return null; }
+        @Override public String getElementStyling(Object e) { return null; }
+        @Override public String getLang(Object e) { return null; }
+        @Override public boolean isLink(Object e) { return false; }
+        @Override public boolean isVisited(Object e) { return false; }
+        @Override public boolean isHover(Object e) { return false; }
+        @Override public boolean isActive(Object e) { return false; }
+        @Override public boolean isFocus(Object e) { return false; }
+        @Override public boolean isMarker(Object e) { return false; }
+    }
+}


### PR DESCRIPTION
Fixes #176.

`Matcher.Mapper.mapChild` runs the full `Selector.matches()` for every selector on every element. This adds a cheap pre-check, `Selector.mayMatch`, that rejects a selector when the element's name, id, or classes cannot satisfy its rightmost simple selector. When it returns false, the full `matches()` is skipped.

The selector loop and its order are unchanged (only an early `continue` is added), so the cascade is preserved. The element name, id, and class tokens are read once per element and reused for all selectors.

On a selector-heavy document of about 15 pages, layout was about two times faster. A unit test checks that `mayMatch` never rejects an element that `matches()` would accept, including the class substring cases from #171.