### PR TITLE
Fix NPE in BlockBox.reset() when the float was already removed

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/BlockBox.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/BlockBox.java
@@ -721,8 +721,11 @@ public class BlockBox extends Box {
         }
 
         if (isFloated()) {
-            _floatedBoxData.getManager().removeFloat(this);
-            _floatedBoxData.getDrawingLayer().removeFloat(this);
+            FloatManager manager = _floatedBoxData.getManager();
+            if (manager != null) {
+                manager.removeFloat(this);
+                _floatedBoxData.getDrawingLayer().removeFloat(this);
+            }
         }
 
         if (getStyle().isRunning()) {


### PR DESCRIPTION
Fixes #178.

[`FloatManager.removeFloat()`](https://github.com/openhtmltopdf/openhtmltopdf/blob/15a767d49e55255a3e66cb694dc2bdb373bed613/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/FloatManager.java#L306) sets the `FloatedBoxData` manager back to null:

```java
floater.getFloatedBoxData().setManager(null);
```

When the box tree is reset more than once, for example while laying out tables that span multiple pages, the second call to `BlockBox.reset()` dereferences that null manager. This PR adds a null guard. When the manager is null, the float was already removed from both the manager and the drawing layer, so there is nothing left to do.

Originally reported in danfickle/openhtmltopdf#987. We hit the same NPE in Orbeon Forms (orbeon/orbeon-forms#7774) and ship this fix in our fork.
