### PR TITLE
Fix #181: resolve target-counter/link/bookmark page from the target's first line box

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/ContentFunctionFactory.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/context/ContentFunctionFactory.java
@@ -39,6 +39,7 @@ import com.openhtmltopdf.render.InlineLayoutBox;
 import com.openhtmltopdf.render.InlineText;
 import com.openhtmltopdf.render.LineBox;
 import com.openhtmltopdf.render.RenderingContext;
+import com.openhtmltopdf.render.displaylist.PagedBoxCollector;
 
 public class ContentFunctionFactory {
     private final List<ContentFunction> _functions = new ArrayList<>();
@@ -204,7 +205,10 @@ public class ContentFunctionFactory {
                 String anchor = uri.substring(1);
                 Box target = c.getBoxById(anchor);
                 if (target != null) {
-                    int pageNo = c.getRootLayer().getRelativePageNo(c, target.getAbsY());
+                    // Use the start of the target's line content rather than its top edge:
+                    // when the target straddles a page break its first line may have been
+                    // pushed to a later page than its top edge.
+                    int pageNo = c.getRootLayer().getRelativePageNo(c, PagedBoxCollector.findContentStartY(target));
                     IdentValue counterStyle = IdentValue.DECIMAL; // default type
                     List<PropertyValue> params = function != null ? function.getParameters() : Collections.emptyList();
                     if (params.size() > 2) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/PagedBoxCollector.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/render/displaylist/PagedBoxCollector.java
@@ -777,6 +777,33 @@ public class PagedBoxCollector {
         PageFinder finder = new PageFinder(pages);
         return finder.findPageAdjusted(c, (int) y);
     }
+
+    /**
+     * Finds the document Y coordinate where the box's content actually starts: the absolute Y
+     * of its first laid-out line box descendant (depth-first), falling back to the box's own
+     * top edge for boxes without line content (empty blocks, replaced elements).
+     * <br><br>
+     * Pagination moves line boxes, not the top edges of their parent blocks, so when a block
+     * straddles a page break its first line may sit on a later page than its top edge. Use
+     * this rather than {@link Box#getAbsY()} to resolve the page a box's content starts on.
+     */
+    public static int findContentStartY(Box box) {
+        Box firstLine = findFirstLineBox(box);
+        return firstLine != null ? firstLine.getAbsY() : box.getAbsY();
+    }
+
+    private static Box findFirstLineBox(Box box) {
+        if (box instanceof LineBox) {
+            return box;
+        }
+        for (int i = 0; i < box.getChildCount(); i++) {
+            Box result = findFirstLineBox(box.getChild(i));
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
     
     public static int getShadowPageForBounds(CssContext c, Rectangle bounds, PageBox page) {
         if (!page.shouldInsertPages()) {

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/bookmark-page-straddle.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/bookmark-page-straddle.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 200px;
+  margin: 0;
+}
+body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 20px;
+}
+h2, p {
+  margin: 0;
+  font-size: 12px;
+}
+h2 {
+  page-break-after: avoid;
+}
+.spacer {
+  height: 170px;
+}
+</style>
+<bookmarks>
+  <bookmark name="Test bookmark" href="#target"/>
+</bookmarks>
+</head>
+<body>
+  <p>First line.</p>
+  <!-- The first line (20px) plus the spacer (170px) leave only 10px on the first
+       page, less than one line height, so the target's first line is pushed to
+       the second page while the target block's top edge stays on the first. -->
+  <div class="spacer"></div>
+  <div id="target">
+    <h2>Target heading</h2>
+    <p>First paragraph.</p>
+    <p>Second paragraph.</p>
+  </div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/target-counter-page-control.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/target-counter-page-control.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 200px;
+  margin: 0;
+}
+body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 20px;
+}
+h2, p {
+  margin: 0;
+  font-size: 12px;
+}
+h2 {
+  page-break-after: avoid;
+}
+.spacer {
+  height: 100px;
+}
+a::after {
+  content: "PAGE-" target-counter(attr(href), page);
+}
+</style>
+</head>
+<body>
+  <p><a href="#target">Link:</a></p>
+  <!-- The spacer leaves 80px on the first page, so the whole target fits and
+       does not straddle the page break. -->
+  <div class="spacer"></div>
+  <div id="target">
+    <h2>Target heading</h2>
+    <p>First paragraph.</p>
+    <p>Second paragraph.</p>
+  </div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/html/target-counter-page-straddle.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/html/target-counter-page-straddle.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 200px;
+  margin: 0;
+}
+body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 20px;
+}
+h2, p {
+  margin: 0;
+  font-size: 12px;
+}
+h2 {
+  page-break-after: avoid;
+}
+.spacer {
+  height: 170px;
+}
+a::after {
+  content: "PAGE-" target-counter(attr(href), page);
+}
+</style>
+</head>
+<body>
+  <p><a href="#target">Link:</a></p>
+  <!-- The link line (20px) plus the spacer (170px) leave only 10px on the first
+       page, less than one line height, so the target's first line is pushed to
+       the second page while the target block's top edge stays on the first. -->
+  <div class="spacer"></div>
+  <div id="target">
+    <h2>Target heading</h2>
+    <p>First paragraph.</p>
+    <p>Second paragraph.</p>
+  </div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/main/resources/visualtest/links/link-dest-page-straddle.html
+++ b/openhtmltopdf-examples/src/main/resources/visualtest/links/link-dest-page-straddle.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+<style>
+@page {
+  size: 200px 200px;
+  margin: 0;
+}
+body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 20px;
+}
+h2, p {
+  margin: 0;
+  font-size: 12px;
+}
+h2 {
+  page-break-after: avoid;
+}
+.spacer {
+  height: 170px;
+}
+</style>
+</head>
+<body>
+  <p><a href="#target">Link to target</a></p>
+  <!-- The link line (20px) plus the spacer (170px) leave only 10px on the first
+       page, less than one line height, so the target's first line is pushed to
+       the second page while the target block's top edge stays on the first. -->
+  <div class="spacer"></div>
+  <div id="target">
+    <h2>Target heading</h2>
+    <p>First paragraph.</p>
+    <p>Second paragraph.</p>
+  </div>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/LinkRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/LinkRegressionTest.java
@@ -53,6 +53,22 @@ public class LinkRegressionTest {
     }
 
     /**
+     * Tests that an internal link's GoTo destination points at the page where the
+     * target's content actually paints when the target block straddles a page break:
+     * the block's top edge lands in the last few pixels of page one, so its first
+     * line (and all of its content) is pushed to page two.
+     */
+    @Test
+    public void testLinkDestPageStraddle() throws IOException {
+        try (TestDocument doc = support.run("link-dest-page-straddle")) {
+            assertEquals(1, doc.pd.getPage(0).getAnnotations().size());
+
+            // The target's content is pushed entirely to the second page.
+            assertThat(linkDestinationPageNo(doc.pd, 0, 0), equalTo(1));
+        }
+    }
+
+    /**
      * Tests that an inline link with multiple inline boxes generates one link annotation for each line.
      * ie. Multiple inline boxes are concatenated into one rect for the purposes of creating a link area.
      */

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -1,10 +1,12 @@
 package com.openhtmltopdf.nonvisualregressiontests;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.*;
 
 import java.awt.Color;
@@ -210,6 +212,78 @@ public class NonVisualRegressionTest {
             assertEquals(doc.getPage(1).getMediaBox().getUpperRightY(), dest.getTop(), 1.0d);
 
             remove("bookmark-head-simple", doc);
+        }
+    }
+
+    /**
+     * Tests that target-counter(attr(href), page) prints the page where the target's
+     * content actually paints when the target block straddles a page break: the block's
+     * top edge lands in the last few pixels of page one, so its first line (and all
+     * of its content) is pushed to page two.
+     */
+    @Test
+    public void testTargetCounterPageStraddle() throws IOException {
+        try (PDDocument doc = run("target-counter-page-straddle")) {
+            assertEquals(2, doc.getNumberOfPages());
+
+            PDFTextStripper stripper = new PDFTextStripper();
+            stripper.setStartPage(1);
+            stripper.setEndPage(1);
+            String page1Text = stripper.getText(doc);
+
+            stripper.setStartPage(2);
+            stripper.setEndPage(2);
+            String page2Text = stripper.getText(doc);
+
+            // The target's content paints entirely on page two...
+            assertThat(page1Text, not(containsString("Target heading")));
+            assertThat(page2Text, containsString("Target heading"));
+
+            // ...so the link must print page two.
+            assertThat(page1Text, containsString("PAGE-2"));
+
+            remove("target-counter-page-straddle", doc);
+        }
+    }
+
+    /**
+     * Control case for {@link #testTargetCounterPageStraddle()}: the target does not
+     * straddle a page break, so target-counter prints the page of the target's top edge.
+     */
+    @Test
+    public void testTargetCounterPageControl() throws IOException {
+        try (PDDocument doc = run("target-counter-page-control")) {
+            PDFTextStripper stripper = new PDFTextStripper();
+            stripper.setStartPage(1);
+            stripper.setEndPage(1);
+            String page1Text = stripper.getText(doc);
+
+            assertThat(page1Text, containsString("Target heading"));
+            assertThat(page1Text, containsString("PAGE-1"));
+
+            remove("target-counter-page-control", doc);
+        }
+    }
+
+    /**
+     * Tests that a bookmark destination points at the page where the target's content
+     * actually paints when the target block straddles a page break (same geometry as
+     * {@link #testTargetCounterPageStraddle()}).
+     */
+    @Test
+    public void testBookmarkPageStraddle() throws IOException {
+        try (PDDocument doc = run("bookmark-page-straddle")) {
+            PDDocumentOutline outline = doc.getDocumentCatalog().getDocumentOutline();
+
+            PDOutlineItem bm = outline.getFirstChild();
+            assertThat(bm.getTitle(), equalTo("Test bookmark"));
+            assertThat(bm.getDestination(), instanceOf(PDPageXYZDestination.class));
+            PDPageXYZDestination dest = (PDPageXYZDestination) bm.getDestination();
+
+            // The target's content is pushed entirely to the second page.
+            assertEquals(doc.getPage(1), dest.getPage());
+
+            remove("bookmark-page-straddle", doc);
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxBookmarkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxBookmarkManager.java
@@ -107,11 +107,26 @@ public class PdfBoxBookmarkManager {
         List<PageBox> pages = root.getLayer().getPages();
         Rectangle bounds = PagedBoxCollector.findAdjustedBoundsForBorderBox(c, box, pages);
 
-        int pageBoxIndex = PagedBoxCollector.findPageForY(c, bounds.getMinY(), pages);
+        double destY = bounds.getMinY();
+
+        // When the box straddles a page break its first line of content may have been
+        // pushed to a later page than its top edge. In that case anchor the destination
+        // to the content start so it points at the page where the content actually paints.
+        // Content start is in untransformed document coordinates, so only use it when no
+        // transform is in effect.
+        if (box.getContainingLayer().getCurrentTransformMatrix() == null) {
+            int contentStartY = PagedBoxCollector.findContentStartY(box);
+            if (PagedBoxCollector.findPageForY(c, contentStartY, pages) >
+                    PagedBoxCollector.findPageForY(c, destY, pages)) {
+                destY = contentStartY;
+            }
+        }
+
+        int pageBoxIndex = PagedBoxCollector.findPageForY(c, destY, pages);
         PageBox page = pages.get(pageBoxIndex);
 
         int distanceFromTop = page.getMarginBorderPadding(c, CalculatedStyle.TOP);
-        distanceFromTop += bounds.getMinY() - page.getTop();
+        distanceFromTop += destY - page.getTop();
 
         int shadowPage = PagedBoxCollector.getShadowPageForBounds(c, bounds, page);
 


### PR DESCRIPTION
Fixes #181.

`target-counter(attr(href), page)`, internal link `GoTo` destinations and bookmark destinations resolved the target's page from the box's top edge (`Box.getAbsY()`). Pagination moves line boxes, not the top edges of their parent blocks, so when the remaining page space is too small for the target's first line, the target's content paints on page N+1 while its top edge stays within page N's span — the printed page number and the destinations pointed one page too early (see #181 for a full analysis and reproduction).

## Changes

- **`PagedBoxCollector.findContentStartY(Box)`** (new helper): returns the absolute Y of a box's first laid-out `LineBox` descendant (depth-first), falling back to the box's own top edge for boxes without line content (empty blocks, replaced elements).
- **`TargetCounterFunction.calculate`**: resolves the page from `findContentStartY(target)` instead of `target.getAbsY()`.
- **`PdfBoxBookmarkManager.createBoxDestination`** (shared by link annotations and bookmarks): anchors the destination to the content start **only** when it lands on a later page than the border-box top, and only when no transform is in effect — the existing border-box math, transform and overflow-clip handling are unchanged in all other cases, so destination coordinates of non-straddling targets are untouched.

Layout itself is unaffected; the change only alters the computed counter text and destination pages. `target-text` is unaffected.

## Tests

The branch is structured tests-first:

1. The first commit adds the regression tests and resources; the three straddle tests **fail** at that commit on top of current `main`, the control test passes.
2. The second commit adds the fix; all four tests pass.

The straddle geometry uses fixed-height spacers (200×200px page, 20px line height, 170px spacer leaves 10px — less than one line — at the page bottom), so the tests do not depend on font metrics:

- `NonVisualRegressionTest#testTargetCounterPageStraddle` — printed counter vs. the page the target's text is extracted on (PDFBox `PDFTextStripper`)
- `NonVisualRegressionTest#testTargetCounterPageControl` — control case (no straddle), passes before and after the fix
- `NonVisualRegressionTest#testBookmarkPageStraddle` — bookmark destination page
- `LinkRegressionTest#testLinkDestPageStraddle` — link `GoTo` destination page

The full `mvn test` suite was run against this branch and against unmodified `main` in the same environment; the results are identical (the only errors in both runs are pre-existing font/AWT environment issues unrelated to this change).

---

Implemented with AI assistance; the defect analysis, test geometry, and fix were human-reviewed, and the tests were verified to fail on unmodified `main` and pass with the fix.
