### PR TITLE
Bump ICU4J from 59.1 to 77.1 in rtl-support (#140)

### DIFF
--- a/openhtmltopdf-rtl-support/pom.xml
+++ b/openhtmltopdf-rtl-support/pom.xml
@@ -56,7 +56,8 @@
     <dependency>
 	<groupId>com.ibm.icu</groupId>
 	<artifactId>icu4j</artifactId>
-	<version>59.1</version>
+	<!-- 77.1 is the newest ICU4J built for Java 8 (78.x requires Java 11). -->
+	<version>77.1</version>
    </dependency>
     <dependency>
         <groupId>io.github.openhtmltopdf</groupId>


### PR DESCRIPTION
77.1 is the newest ICU4J built for Java 8 (class file version 52); 78.x is compiled for Java 11 and would break the Java 8 build.

Note that CVE-2025-10492, which prompted #140, is a JasperReports deserialisation vulnerability and does not affect ICU4J itself. Dependency scanners misattribute it, and ICU4C CVEs such as CVE-2017-14952, to icu4j 59.1. The bump is still worthwhile: eight years of Unicode/bidi updates, and icu4j no longer shares a version number with the genuinely vulnerable icu4c 59.1.

Verified with the full openhtmltopdf-examples suite including the RTL visual regression tests (241 tests, all green).