### PR TITLE
Fix cross-document sharing of built-in fonts corrupting saved PDFs

### DIFF
--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -379,7 +379,7 @@ public class NonVisualRegressionTest {
             PDAnnotationWidget widget = (PDAnnotationWidget) doc.getPage(0).getAnnotations().get(0);
             assertThat(widget.getRectangle(), rectEquals(new PDRectangle(23f, 23f, 100f, 20f), 200));
 
-            PDAcroForm form = doc.getDocumentCatalog().getAcroForm(null);
+            PDAcroForm form = doc.getDocumentCatalog().getAcroForm();
             assertEquals(1, form.getFields().size());
             assertThat(form.getFields().get(0), instanceOf(PDTextField.class));
 
@@ -405,7 +405,7 @@ public class NonVisualRegressionTest {
             PDAnnotationWidget widget = (PDAnnotationWidget) doc.getPage(1).getAnnotations().get(0);
             assertThat(widget.getRectangle(), rectEquals(new PDRectangle(33f, 14f, 40f, 20f), 100));
 
-            PDAcroForm form = doc.getDocumentCatalog().getAcroForm(null);
+            PDAcroForm form = doc.getDocumentCatalog().getAcroForm();
             assertEquals(1, form.getFields().size());
             assertThat(form.getFields().get(0), instanceOf(PDTextField.class));
 
@@ -444,7 +444,7 @@ public class NonVisualRegressionTest {
             assertTrue(page1.getMediaBox().contains(rectangle1.getLowerLeftX(), rectangle1.getLowerLeftY()));
             assertTrue(page1.getMediaBox().contains(rectangle1.getUpperRightX(), rectangle1.getUpperRightY()));
 
-            PDAcroForm form = doc.getDocumentCatalog().getAcroForm(null);
+            PDAcroForm form = doc.getDocumentCatalog().getAcroForm();
             assertEquals(2, form.getFields().size());
             assertThat(form.getFields().get(0), instanceOf(PDTextField.class));
             assertThat(form.getFields().get(1), instanceOf(PDTextField.class));
@@ -473,7 +473,7 @@ public class NonVisualRegressionTest {
             PDAnnotationWidget widget = (PDAnnotationWidget) doc.getPage(2).getAnnotations().get(0);
             assertThat(widget.getRectangle(), rectEquals(new PDRectangle(13f, 13f, 60f, 30f), 100));
 
-            PDAcroForm form = doc.getDocumentCatalog().getAcroForm(null);
+            PDAcroForm form = doc.getDocumentCatalog().getAcroForm();
             assertEquals(1, form.getFields().size());
             assertThat(form.getFields().get(0), instanceOf(PDTextField.class));
 
@@ -482,6 +482,24 @@ public class NonVisualRegressionTest {
             assertEquals("Hello World!", field.getValue());
 
             remove("form-control-after-overflow-page", doc);
+        }
+    }
+
+    /**
+     * Every font written to the AcroForm default resources must carry the
+     * required /BaseFont entry, even when the control's font is used by no
+     * page content (its subset would stay empty and be saved unnamed).
+     */
+    @Test
+    public void testFormControlFontHasBaseFont() throws IOException {
+        try (PDDocument doc = run("form-control-on-second-page")) {
+            // Pass null to inspect the raw written form, without fixups.
+            PDAcroForm form = doc.getDocumentCatalog().getAcroForm(null);
+            for (COSName fontName : form.getDefaultResources().getFontNames()) {
+                assertNotNull("/BaseFont missing for " + fontName.getName(),
+                        form.getDefaultResources().getFont(fontName).getName());
+            }
+            remove("form-control-on-second-page", doc);
         }
     }
 

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/AbstractFontStore.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/fontstore/AbstractFontStore.java
@@ -31,7 +31,13 @@ public abstract class AbstractFontStore {
     }
 
     public static class BuiltinFontStore extends AbstractFontStore {
-        static final Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> _fontFamilies = createInitialFontMap();
+        // Must be per instance (ie. per document): the PDType1Font objects and
+        // their COS dictionaries end up in every document that uses them, and
+        // PDFBox (>= 3.0.4) caches object keys on the COS objects while saving,
+        // so a COS object shared between documents is written into the second
+        // document as a dangling reference ("found wrong object number"
+        // warnings, empty font dictionaries on read-back).
+        final Map<String, FontFamily<PdfBoxFontResolver.FontDescription>> _fontFamilies = createInitialFontMap();
 
         public BuiltinFontStore() {
         }


### PR DESCRIPTION
Since #150 the BuiltinFontStore font map is static, so the standard-14 PDType1Font objects and their COS dictionaries are shared by every document rendered in the same JVM. PDFBox >= 3.0.4 caches object keys on COS objects while saving, so the second and every later document that uses a built-in font writes a dangling reference instead of the font dictionary ('found wrong object number' warnings, empty font dictionaries on read-back). Most viewers mask this by substituting a fallback font; the loudest symptom was the NPE in PDFBox's default AcroForm fixup that #183 had to work around in the form tests.

Make the font map per store instance (ie. per document) again. The PDType1Font constructor is cheap since PDFBox caches the parsed standard-14 AFM data process-wide, so the #149 concern does not return. Revert the four getAcroForm(null) workarounds so the form tests exercise the default fixup again, and add a test asserting the required /BaseFont entry on every AcroForm default-resource font.