### PR TITLE
For #191: bucket selectors by id, class and name in Matcher

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
@@ -22,12 +22,14 @@ package com.openhtmltopdf.css.newmatch;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +54,12 @@ public class Matcher {
     private final StylesheetFactory _styleFactory;
 
     private final Map<Object, Mapper> _map = new HashMap<>();
+
+    /**
+     * RuleIndex per axes list (by identity). Child Mappers usually share their
+     * parent's descendant selectors as their axes, so they share one index.
+     */
+    private final Map<List<Selector>, RuleIndex> _indexCache = new IdentityHashMap<>();
 
     private final Set<Object> _hoverElements = new HashSet<>();
     private final Set<Object> _activeElements = new HashSet<>();
@@ -94,7 +102,7 @@ public class Matcher {
         Object parent = _treeRes.getParentElement(e);
         Mapper child = parent != null ? getMapper(parent) : docMapper;
 
-        AllDescendantMapper descendants = new AllDescendantMapper(child.axes, _attRes, _treeRes);
+        AllDescendantMapper descendants = new AllDescendantMapper(child.axes(), _attRes, _treeRes);
         descendants.map(e);
 
         return descendants.toCSS();
@@ -303,17 +311,207 @@ public class Matcher {
     }
 
     /**
+     * Index of a Mapper's axes by each selector's own simple selector (the
+     * {@link Selector#mayMatch} fields: name, id, classes), so that mapChild
+     * only visits selectors that may match an element. Buckets hold positions
+     * in the indexed list; candidates are returned in ascending position
+     * (cascade) order.
+     */
+    private static class RuleIndex {
+        private final Selector[] selectors;
+        private final Map<String, int[]> byId;
+        private final Map<String, int[]> byClass;
+        private final Map<String, int[]> byName;
+        /** Selectors with no name/id/class requirement; checked for every element. */
+        private final int[] universal;
+
+        /**
+         * The descendant-axis selectors in order: the childAxes of an element
+         * that activates no chained selector. Shared, never mutated; the
+         * indexed list itself when every selector is descendant-axis, so
+         * Mappers below share this index.
+         */
+        final List<Selector> defaultChildAxes;
+        /** Positions (in the indexed list) of the defaultChildAxes selectors. */
+        private final int[] descendantPositions;
+
+        RuleIndex(List<Selector> axes) {
+            int size = axes.size();
+            selectors = axes.toArray(new Selector[size]);
+
+            Map<String, List<Integer>> id = new HashMap<>();
+            // Sized for class-heavy stylesheets, where most selectors get
+            // their own byClass bucket.
+            Map<String, List<Integer>> cls = new HashMap<>(Math.max(16, size * 2));
+            Map<String, List<Integer>> name = new HashMap<>();
+            int[] universalTmp = new int[size];
+            int universalCount = 0;
+            int[] descendantsTmp = new int[size];
+            int descendantCount = 0;
+
+            for (int i = 0; i < size; i++) {
+                Selector sel = selectors[i];
+
+                if (sel.getAxis() == Selector.DESCENDANT_AXIS) {
+                    descendantsTmp[descendantCount++] = i;
+                }
+
+                if (sel.getAxis() == Selector.IMMEDIATE_SIBLING_AXIS) {
+                    // Always visited, so mapChild still throws on it.
+                    universalTmp[universalCount++] = i;
+                } else if (sel.indexId() != null) {
+                    id.computeIfAbsent(sel.indexId(), k -> new ArrayList<>()).add(i);
+                } else if (sel.indexClass() != null) {
+                    cls.computeIfAbsent(sel.indexClass(), k -> new ArrayList<>()).add(i);
+                } else if (sel.indexName() != null) {
+                    name.computeIfAbsent(sel.indexName(), k -> new ArrayList<>()).add(i);
+                } else {
+                    universalTmp[universalCount++] = i;
+                }
+            }
+
+            byId = freeze(id);
+            byClass = freeze(cls);
+            byName = freeze(name);
+            universal = Arrays.copyOf(universalTmp, universalCount);
+            descendantPositions = Arrays.copyOf(descendantsTmp, descendantCount);
+
+            if (descendantCount == size) {
+                defaultChildAxes = axes;
+            } else {
+                List<Selector> dca = new ArrayList<>(descendantCount);
+                for (int pos : descendantPositions) {
+                    dca.add(selectors[pos]);
+                }
+                defaultChildAxes = dca;
+            }
+        }
+
+        Selector selector(int pos) {
+            return selectors[pos];
+        }
+
+        /**
+         * Positions of the selectors that may match an element with the given
+         * name, id and class tokens, in ascending (cascade) order. A selector
+         * is in exactly one bucket, so there are no duplicates.
+         */
+        int[] candidates(String name, String id, Set<String> classes) {
+            int[] nameBucket = name != null ? byName.get(name) : null;
+            int[] idBucket = id != null ? byId.get(id) : null;
+
+            int total = universal.length
+                    + (nameBucket != null ? nameBucket.length : 0)
+                    + (idBucket != null ? idBucket.length : 0);
+
+            int[][] classBuckets = null;
+            int classBucketCount = 0;
+            if (classes != null && !classes.isEmpty() && !byClass.isEmpty()) {
+                classBuckets = new int[classes.size()][];
+                for (String c : classes) {
+                    int[] b = byClass.get(c);
+                    if (b != null) {
+                        classBuckets[classBucketCount++] = b;
+                        total += b.length;
+                    }
+                }
+            }
+
+            if (total == universal.length) {
+                // No bucket hit; universal is already in ascending order.
+                return universal;
+            }
+
+            int[] result = new int[total];
+            int n = copy(universal, result, 0);
+            if (nameBucket != null) {
+                n = copy(nameBucket, result, n);
+            }
+            if (idBucket != null) {
+                n = copy(idBucket, result, n);
+            }
+            for (int i = 0; i < classBucketCount; i++) {
+                n = copy(classBuckets[i], result, n);
+            }
+            Arrays.sort(result);
+            return result;
+        }
+
+        /**
+         * defaultChildAxes with the chained selectors spliced in at their
+         * producers' positions. Both inputs are in ascending position order;
+         * on equal position the carried descendant selector (the chain's
+         * producer) comes first, as in the original single-pass loop.
+         */
+        List<Selector> mergeChained(List<Selector> chainedSelectors, int[] chainedPositions, int chainedCount) {
+            List<Selector> result = new ArrayList<>(defaultChildAxes.size() + chainedCount);
+            int d = 0;
+            for (int c = 0; c < chainedCount; c++) {
+                int pos = chainedPositions[c];
+                while (d < descendantPositions.length && descendantPositions[d] <= pos) {
+                    result.add(defaultChildAxes.get(d));
+                    d++;
+                }
+                result.add(chainedSelectors.get(c));
+            }
+            while (d < descendantPositions.length) {
+                result.add(defaultChildAxes.get(d));
+                d++;
+            }
+            return result;
+        }
+
+        private static Map<String, int[]> freeze(Map<String, List<Integer>> src) {
+            if (src.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            Map<String, int[]> result = new HashMap<>(src.size() * 2);
+            for (Map.Entry<String, List<Integer>> en : src.entrySet()) {
+                result.put(en.getKey(), toIntArray(en.getValue()));
+            }
+            return result;
+        }
+
+        private static int[] toIntArray(List<Integer> src) {
+            int[] result = new int[src.size()];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = src.get(i);
+            }
+            return result;
+        }
+
+        private static int copy(int[] src, int[] dst, int at) {
+            System.arraycopy(src, 0, dst, at, src.length);
+            return at + src.length;
+        }
+    }
+
+    /**
      * Mapper represents a local CSS for a Node that is used to match the Node's
      * children.
      *
      * @author Torbjoern Gannholm
      */
     class Mapper {
-        private final List<Selector> axes;
+        private List<Selector> axes;
         private final Map<String, List<Selector>> pseudoSelectors;
         private final List<Selector> mappedSelectors;
 
         private Map<String, Mapper> children;
+
+        /** Lazily built (and shared through Matcher._indexCache) index of axes. */
+        private RuleIndex index;
+
+        /**
+         * Deferred axes: the parent's index and the chained selectors this
+         * Mapper's element activated. Merged into {@link #axes} only when
+         * first needed, i.e. if this Mapper ever maps children of its own;
+         * cleared after the merge.
+         */
+        private RuleIndex mergeSource;
+        private List<Selector> mergeChains;
+        private int[] mergeChainPositions;
+        private int mergeChainCount;
 
         Mapper(Collection<Selector> selectors) {
             this.axes = new ArrayList<>(selectors);
@@ -330,6 +528,31 @@ public class Matcher {
             this.pseudoSelectors = pseudoSelectors;
         }
 
+        private Mapper(
+                RuleIndex mergeSource,
+                List<Selector> mergeChains,
+                int[] mergeChainPositions,
+                int mergeChainCount,
+                List<Selector> mappedSelectors,
+                Map<String,List<Selector>> pseudoSelectors) {
+            this.mergeSource = mergeSource;
+            this.mergeChains = mergeChains;
+            this.mergeChainPositions = mergeChainPositions;
+            this.mergeChainCount = mergeChainCount;
+            this.mappedSelectors = mappedSelectors;
+            this.pseudoSelectors = pseudoSelectors;
+        }
+
+        List<Selector> axes() {
+            if (axes == null) {
+                axes = mergeSource.mergeChained(mergeChains, mergeChainPositions, mergeChainCount);
+                mergeSource = null;
+                mergeChains = null;
+                mergeChainPositions = null;
+            }
+            return axes;
+        }
+
         /**
          * Side effect: creates and stores a Mapper for the element
          *
@@ -338,26 +561,32 @@ public class Matcher {
          *         (more correct: preserves the sort order from Matcher creation)
          */
         Mapper mapChild(Object e) {
-            List<Selector> childAxes = null;
             List<Selector> mappedSelectors = null;
             Map<String, List<Selector>> pseudoSelectors = null;
 
             StringBuilder key = new StringBuilder();
 
-            // Read once per element and reused by Selector.mayMatch for every candidate selector.
+            // Read once per element and reused for every candidate selector.
             String elementName = _treeRes.getElementName(e);
             String elementId = _attRes != null ? _attRes.getID(e) : null;
             Set<String> elementClasses = classTokens(_attRes != null ? _attRes.getClass(e) : null);
 
-            for (Selector sel : axes) {
-                if (sel.getAxis() == Selector.DESCENDANT_AXIS) {
-                    if (childAxes == null) {
-                        childAxes = new ArrayList<>();
-                    }
+            if (index == null) {
+                index = _indexCache.computeIfAbsent(axes(), RuleIndex::new);
+            }
 
-                    // Carry it forward to other descendants
-                    childAxes.add(sel);
-                } else if (sel.getAxis() == Selector.IMMEDIATE_SIBLING_AXIS) {
+            // Chained selectors activated by this element, with their
+            // producers' positions in axes; spliced into defaultChildAxes.
+            List<Selector> chainedSelectors = null;
+            int[] chainedPositions = null;
+            int chainedCount = 0;
+
+            int[] candidates = index.candidates(elementName, elementId, elementClasses);
+
+            for (int pos : candidates) {
+                Selector sel = index.selector(pos);
+
+                if (sel.getAxis() == Selector.IMMEDIATE_SIBLING_AXIS) {
                     throw new RuntimeException();
                 }
 
@@ -417,11 +646,15 @@ public class Matcher {
                 } else if (chain.getAxis() == Selector.IMMEDIATE_SIBLING_AXIS) {
                     throw new RuntimeException();
                 } else {
-                    if (childAxes == null) {
-                        childAxes = new ArrayList<>();
+                    if (chainedSelectors == null) {
+                        chainedSelectors = new ArrayList<>();
+                        chainedPositions = new int[8];
+                    } else if (chainedCount == chainedPositions.length) {
+                        chainedPositions = Arrays.copyOf(chainedPositions, chainedCount * 2);
                     }
 
-                    childAxes.add(chain);
+                    chainedSelectors.add(chain);
+                    chainedPositions[chainedCount++] = pos;
                 }
             }
 
@@ -429,16 +662,26 @@ public class Matcher {
                 children = new HashMap<>();
             }
 
-            List<Selector> normalisedChildAxes = childAxes == null ? Collections.emptyList() : childAxes;
-            List<Selector> normalisedMappedSelectors = mappedSelectors == null ? Collections.emptyList() : mappedSelectors;
-            Map<String, List<Selector>> normalisedPseudoSelectors = pseudoSelectors == null ? Collections.emptyMap() : pseudoSelectors;
+            String childKey = key.toString();
+            Mapper childMapper = children.get(childKey);
+            if (childMapper == null) {
+                List<Selector> normalisedMappedSelectors = mappedSelectors == null ? Collections.emptyList() : mappedSelectors;
+                Map<String, List<Selector>> normalisedPseudoSelectors = pseudoSelectors == null ? Collections.emptyMap() : pseudoSelectors;
 
-            Mapper childMapper = children.computeIfAbsent(
-                    key.toString(),
-                    kee -> new Mapper(
-                        normalisedChildAxes,
-                        normalisedMappedSelectors,
-                        normalisedPseudoSelectors));
+                childMapper = chainedSelectors == null
+                        ? new Mapper(
+                            index.defaultChildAxes,
+                            normalisedMappedSelectors,
+                            normalisedPseudoSelectors)
+                        : new Mapper(
+                            index,
+                            chainedSelectors,
+                            chainedPositions,
+                            chainedCount,
+                            normalisedMappedSelectors,
+                            normalisedPseudoSelectors);
+                children.put(childKey, childMapper);
+            }
 
             link(e, childMapper);
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
@@ -135,6 +135,21 @@ public class Selector {
         return true;
     }
 
+    /** This selector's required id, for Matcher's rule index; null if none. */
+    String indexId() {
+        return _requiredId;
+    }
+
+    /** One of this selector's required classes, for Matcher's rule index; null if none. */
+    String indexClass() {
+        return _requiredClasses != null ? _requiredClasses.get(0) : null;
+    }
+
+    /** This selector's element name, for Matcher's rule index; null if none. */
+    String indexName() {
+        return _name;
+    }
+
     /**
      * Check if the given Element matches this selector's dynamic properties.
      * Note: the parser should give all class

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/newmatch/MatcherRuleIndexTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/newmatch/MatcherRuleIndexTest.java
@@ -1,0 +1,467 @@
+package com.openhtmltopdf.css.newmatch;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.TreeMap;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.extend.AttributeResolver;
+import com.openhtmltopdf.css.extend.TreeResolver;
+import com.openhtmltopdf.css.extend.lib.DOMTreeResolver;
+import com.openhtmltopdf.css.parser.CSSParser;
+import com.openhtmltopdf.css.sheet.PropertyDeclaration;
+import com.openhtmltopdf.css.sheet.Ruleset;
+import com.openhtmltopdf.css.sheet.Stylesheet;
+import com.openhtmltopdf.css.sheet.StylesheetInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Element-level tests for {@link Matcher} with the rightmost-simple-selector
+ * rule index: bucket routing, cascade order across buckets, chained-selector
+ * splicing, and a seeded differential test against a naive reference matcher.
+ */
+public class MatcherRuleIndexTest {
+
+    private static final AttributeResolver ATT_RES = new DomAttributeResolver();
+    private static final TreeResolver TREE_RES = new DOMTreeResolver();
+
+    // ---------------------------------------------------------------- harness
+
+    private static Stylesheet parse(String css) {
+        try {
+            return new CSSParser((uri, message) -> fail("CSS parse error: " + message))
+                    .parseStylesheet("test://css", StylesheetInfo.AUTHOR, new StringReader(css));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Matcher matcher(Stylesheet sheet) {
+        return new Matcher(TREE_RES, ATT_RES, null, Collections.singletonList(sheet), "print");
+    }
+
+    private static Matcher matcher(String css) {
+        return matcher(parse(css));
+    }
+
+    private static Document dom(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Element byId(Document doc, String id) {
+        NodeList all = doc.getElementsByTagName("*");
+        for (int i = 0; i < all.getLength(); i++) {
+            Element e = (Element) all.item(i);
+            if (id.equals(e.getAttribute("id"))) {
+                return e;
+            }
+        }
+        throw new AssertionError("no element with id " + id);
+    }
+
+    /** The cascaded letter-spacing value for the element, or null when no rule matched. */
+    private static String spacing(Matcher m, Element e) {
+        PropertyDeclaration pd = m.getCascadedStyle(e, false).propertyByName(CSSName.LETTER_SPACING);
+        return pd == null ? null : pd.getValue().getCssText();
+    }
+
+    // --------------------------------------------------------- targeted tests
+
+    @Test
+    public void bucketsRouteIdClassNameAndUniversal() {
+        Matcher m = matcher(
+                "#i { letter-spacing: 1px }\n" +
+                ".c { letter-spacing: 2px }\n" +
+                "p { letter-spacing: 3px }\n" +
+                "[data-k] { letter-spacing: 4px }\n");
+        Document doc = dom("<r>" +
+                "<div id='i'/><div id='cls' class='c'/><p id='p1'/>" +
+                "<span id='attr' data-k='v'/><span id='none'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "i")));
+        assertEquals("2px", spacing(m, byId(doc, "cls")));
+        assertEquals("3px", spacing(m, byId(doc, "p1")));
+        assertEquals("4px", spacing(m, byId(doc, "attr")));
+        assertNull(spacing(m, byId(doc, "none")));
+    }
+
+    @Test
+    public void laterRuleWinsAcrossClassAndUniversalBuckets() {
+        // .a and [class~=a] have the same specificity but land in different buckets.
+        Document doc = dom("<r><div id='d' class='a'/></r>");
+        assertEquals("2px", spacing(
+                matcher(".a { letter-spacing: 1px }\n[class~=a] { letter-spacing: 2px }"), byId(doc, "d")));
+        assertEquals("1px", spacing(
+                matcher("[class~=a] { letter-spacing: 2px }\n.a { letter-spacing: 1px }"), byId(doc, "d")));
+    }
+
+    @Test
+    public void laterRuleWinsAcrossTwoClassBuckets() {
+        Document doc = dom("<r><div id='d' class='a b'/></r>");
+        assertEquals("2px", spacing(
+                matcher(".a { letter-spacing: 1px }\n.b { letter-spacing: 2px }"), byId(doc, "d")));
+        assertEquals("1px", spacing(
+                matcher(".b { letter-spacing: 2px }\n.a { letter-spacing: 1px }"), byId(doc, "d")));
+    }
+
+    @Test
+    public void multiClassSelectorAppliesOnce() {
+        Matcher m = matcher(".a.b { letter-spacing: 1px }");
+        Document doc = dom("<r><i id='ab' class='b a'/><i id='a' class='a'/><i id='b' class='b'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "ab")));
+        assertNull(spacing(m, byId(doc, "a")));
+        assertNull(spacing(m, byId(doc, "b")));
+    }
+
+    @Test
+    public void descendantChainMatchesAtAnyDepth() {
+        Matcher m = matcher("div .x { letter-spacing: 1px }");
+        Document doc = dom("<r><div><p class='x' id='child'/><p><span class='x' id='grand'/></p></div>" +
+                "<p class='x' id='outside'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "child")));
+        assertEquals("1px", spacing(m, byId(doc, "grand")));
+        assertNull(spacing(m, byId(doc, "outside")));
+    }
+
+    @Test
+    public void childChainMatchesImmediateChildrenOnly() {
+        Matcher m = matcher("div > .x { letter-spacing: 1px }");
+        Document doc = dom("<r><div><p class='x' id='child'/><p><span class='x' id='grand'/></p></div></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "child")));
+        assertNull(spacing(m, byId(doc, "grand")));
+    }
+
+    @Test
+    public void chainSpliceOrderFollowsDeclarationOrder() {
+        // Both chains reach the span with equal specificity via different producers,
+        // so the merged child axes order decides the cascade: later-declared wins.
+        Document doc = dom("<r><body><div><span id='s'/></div></body></r>");
+        assertEquals("2px", spacing(
+                matcher("body span { letter-spacing: 1px }\ndiv span { letter-spacing: 2px }"), byId(doc, "s")));
+        assertEquals("1px", spacing(
+                matcher("div span { letter-spacing: 2px }\nbody span { letter-spacing: 1px }"), byId(doc, "s")));
+    }
+
+    @Test
+    public void siblingSelector() {
+        Matcher m = matcher(".a + .b { letter-spacing: 1px }");
+        Document doc = dom("<r><i class='a'/><i class='b' id='second'/><i class='b' id='third'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "second")));
+        assertNull(spacing(m, byId(doc, "third")));
+    }
+
+    @Test
+    public void dynamicConditionInsideClassBucket() {
+        Matcher m = matcher(".a:first-child { letter-spacing: 1px }");
+        Document doc = dom("<r><i class='a' id='first'/><i class='a' id='second'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "first")));
+        assertNull(spacing(m, byId(doc, "second")));
+    }
+
+    @Test
+    public void pseudoElementSelectorsGoToPseudoStyles() {
+        Matcher m = matcher(".a:before { content: \"x\" }");
+        Document doc = dom("<r><i class='a' id='e'/></r>");
+        Element e = byId(doc, "e");
+
+        assertEquals(0, m.getCascadedStyle(e, false).countAssigned());
+        CascadedStyle pe = m.getPECascadedStyle(e, "before");
+        assertNotNull(pe);
+        assertTrue(pe.hasProperty(CSSName.CONTENT));
+    }
+
+    @Test
+    public void duplicateClassTokens() {
+        Matcher m = matcher(".a { letter-spacing: 1px }");
+        Document doc = dom("<r><i id='e' class='a a'/></r>");
+
+        assertEquals("1px", spacing(m, byId(doc, "e")));
+    }
+
+    @Test
+    public void getCSSForAllDescendantsAfterChainActivation() {
+        // Exercises the deferred axes materialization (Mapper.axes()) of a Mapper
+        // whose element activated a chained selector.
+        Matcher m = matcher("div p span { color: red }");
+        Document doc = dom("<r><div><p id='p'><span/></p></div></r>");
+
+        m.getCascadedStyle(byId(doc, "p"), false);
+        String css = m.getCSSForAllDescendants(byId(doc, "p"));
+        assertTrue(css, css.contains("span"));
+        assertTrue(css, css.contains("color"));
+    }
+
+    @Test
+    public void manyChainsFromOneElementAndInternedMapperReuse() {
+        // One element activating more than 8 chains exercises the growth of
+        // mapChild's chainedPositions array (initial size 8). The second,
+        // identically matched sibling then reuses the same interned child
+        // Mapper, whose deferred axes were already materialized.
+        StringBuilder css = new StringBuilder();
+        for (int i = 0; i < 10; i++) {
+            css.append(".a s").append(i).append(" { letter-spacing: ").append(i + 1).append("px }\n");
+        }
+        StringBuilder xml = new StringBuilder("<r>");
+        for (String prefix : new String[] {"c", "d"}) {
+            xml.append("<div class='a'>");
+            for (int i = 0; i < 10; i++) {
+                xml.append("<s").append(i).append(" id='").append(prefix).append(i).append("'/>");
+            }
+            xml.append("</div>");
+        }
+        xml.append("</r>");
+
+        Matcher m = matcher(css.toString());
+        Document doc = dom(xml.toString());
+        for (String prefix : new String[] {"c", "d"}) {
+            for (int i = 0; i < 10; i++) {
+                assertEquals((i + 1) + "px", spacing(m, byId(doc, prefix + i)));
+            }
+        }
+    }
+
+    @Test
+    public void mergedAxesPreserveCarriedBeforeChainOnEqualPosition() {
+        // Pins mergeChained at list level: on equal position the carried
+        // descendant producer comes before the chain it produced (the `<=`
+        // tie-break), with other descendant selectors around them by position.
+        Stylesheet sheet = parse(
+                "div div { letter-spacing: 1px }\n" +
+                "span { letter-spacing: 2px }\n");
+        Selector divTop = ((Ruleset) sheet.getContents().get(0)).getFSSelectors().get(0);
+        Selector divChain = divTop.getChainedSelector();
+        Selector spanTop = ((Ruleset) sheet.getContents().get(1)).getFSSelectors().get(0);
+
+        Matcher m = matcher(sheet);
+        Document doc = dom("<r><div id='outer'><div id='inner'/></div></r>");
+
+        // The sorted base list is [span, div] (specificity 1 vs 2), and the
+        // outer div activated the `div div` chain at the producer's position.
+        Matcher.Mapper outerMapper = m.matchElement(byId(doc, "outer"));
+        List<Selector> axes = outerMapper.axes();
+        assertEquals(3, axes.size());
+        assertSame(spanTop, axes.get(0));
+        assertSame(divTop, axes.get(1));   // carried producer first...
+        assertSame(divChain, axes.get(2)); // ...then the chain it produced
+
+        assertEquals("1px", spacing(m, byId(doc, "inner")));
+    }
+
+    // ------------------------------------------------------- differential test
+
+    private static final String[] TAGS = {"div", "p", "span", "i", "b"};
+    private static final String[] CLASSES = {"a", "b", "c"};
+    private static final String[] IDS = {"x", "y", "z"};
+
+    /**
+     * Renders many random small trees and compares, for every element, the
+     * cascaded letter-spacing winner between the indexed Matcher and a naive
+     * reference that evaluates each selector chain by walking the DOM.
+     */
+    @Test
+    public void differentialAgainstNaiveReference() throws Exception {
+        Stylesheet sheet = parse(
+                "* { letter-spacing: 1px }\n" +
+                "div { letter-spacing: 2px }\n" +
+                "p { letter-spacing: 3px }\n" +
+                "span { letter-spacing: 4px }\n" +
+                ".a { letter-spacing: 5px }\n" +
+                ".b { letter-spacing: 6px }\n" +
+                ".c { letter-spacing: 7px }\n" +
+                ".a.b { letter-spacing: 8px }\n" +
+                "#x { letter-spacing: 9px }\n" +
+                "#y { letter-spacing: 10px }\n" +
+                "div .a { letter-spacing: 11px }\n" +
+                "div > .b { letter-spacing: 12px }\n" +
+                "p span { letter-spacing: 13px }\n" +
+                "div p .a { letter-spacing: 14px }\n" +
+                ".a .b { letter-spacing: 15px }\n" +
+                ".c > span { letter-spacing: 16px }\n" +
+                "div + p { letter-spacing: 17px }\n" +
+                ".a + .b { letter-spacing: 18px }\n" +
+                "span:first-child { letter-spacing: 19px }\n" +
+                "div [data-k] { letter-spacing: 20px }\n" +
+                "div .a > span { letter-spacing: 21px }\n" +
+                "[data-k=v] { letter-spacing: 22px }\n" +
+                "i b { letter-spacing: 23px }\n" +
+                "p > .c .a { letter-spacing: 24px }\n");
+
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Random rnd = new Random(20260720L);
+        int matched = 0;
+
+        for (int tree = 0; tree < 40; tree++) {
+            Matcher m = matcher(sheet);
+
+            // Same order as Matcher.createDocumentMapper; positions were just set by the ctor.
+            TreeMap<String, Selector> sorter = new TreeMap<>();
+            for (Object content : sheet.getContents()) {
+                for (Selector sel : ((Ruleset) content).getFSSelectors()) {
+                    sorter.put(sel.getOrder(), sel);
+                }
+            }
+
+            Document doc = builder.newDocument();
+            Element root = doc.createElement("div");
+            doc.appendChild(root);
+            grow(doc, root, rnd, 0);
+
+            NodeList all = doc.getElementsByTagName("*");
+            for (int i = 0; i < all.getLength(); i++) {
+                Element e = (Element) all.item(i);
+
+                String expected = null;
+                for (Selector top : sorter.values()) {
+                    if (top.getPseudoElement() == null && chainMatches(top, e)) {
+                        expected = top.getRuleset().getPropertyDeclarations().get(0).getValue().getCssText();
+                    }
+                }
+
+                assertEquals(describe(e), expected, spacing(m, e));
+                if (expected != null) {
+                    matched++;
+                }
+            }
+        }
+
+        assertTrue("differential test never matched anything", matched > 200);
+    }
+
+    private static void grow(Document doc, Element parent, Random rnd, int depth) {
+        if (depth >= 4) {
+            return;
+        }
+        int count = rnd.nextInt(4);
+        for (int i = 0; i < count; i++) {
+            Element e = doc.createElement(TAGS[rnd.nextInt(TAGS.length)]);
+            double r = rnd.nextDouble();
+            if (r < 0.30) {
+                e.setAttribute("class", CLASSES[rnd.nextInt(CLASSES.length)]);
+            } else if (r < 0.45) {
+                e.setAttribute("class",
+                        CLASSES[rnd.nextInt(CLASSES.length)] + " " + CLASSES[rnd.nextInt(CLASSES.length)]);
+            }
+            if (rnd.nextDouble() < 0.10) {
+                e.setAttribute("id", IDS[rnd.nextInt(IDS.length)]);
+            }
+            if (rnd.nextDouble() < 0.20) {
+                e.setAttribute("data-k", rnd.nextBoolean() ? "v" : "w");
+            }
+            parent.appendChild(e);
+            grow(doc, e, rnd, depth + 1);
+        }
+    }
+
+    /**
+     * Naive reference: the chain (leftmost link first) matches e when its last
+     * link matches e and each earlier link matches an ancestor per the axis of
+     * the link to its right. Sibling selectors are handled inside matches().
+     */
+    private static boolean chainMatches(Selector top, Element e) {
+        List<Selector> links = new ArrayList<>();
+        for (Selector s = top; s != null; s = s.getChainedSelector()) {
+            links.add(s);
+        }
+        return matchesAt(links, links.size() - 1, e);
+    }
+
+    private static boolean matchesAt(List<Selector> links, int i, Element e) {
+        Selector s = links.get(i);
+        if (!s.matches(e, ATT_RES, TREE_RES) || !s.matchesDynamic(e, ATT_RES, TREE_RES)) {
+            return false;
+        }
+        if (i == 0) {
+            return true;
+        }
+        Node p = e.getParentNode();
+        if (s.getAxis() == Selector.CHILD_AXIS) {
+            return p instanceof Element && matchesAt(links, i - 1, (Element) p);
+        }
+        // DESCENDANT_AXIS: any proper ancestor
+        while (p instanceof Element) {
+            if (matchesAt(links, i - 1, (Element) p)) {
+                return true;
+            }
+            p = p.getParentNode();
+        }
+        return false;
+    }
+
+    private static String describe(Element e) {
+        StringBuilder sb = new StringBuilder(e.getNodeName());
+        if (e.hasAttribute("class")) {
+            sb.append(" class=\"").append(e.getAttribute("class")).append('"');
+        }
+        if (e.hasAttribute("id")) {
+            sb.append(" id=\"").append(e.getAttribute("id")).append('"');
+        }
+        Node p = e.getParentNode();
+        while (p instanceof Element) {
+            sb.append(" < ").append(p.getNodeName());
+            p = p.getParentNode();
+        }
+        return sb.toString();
+    }
+
+    // -------------------------------------------------------------- resolvers
+
+    private static final class DomAttributeResolver implements AttributeResolver {
+        @Override
+        public String getAttributeValue(Object o, String attrName) {
+            Element e = (Element) o;
+            return e.hasAttribute(attrName) ? e.getAttribute(attrName) : null;
+        }
+
+        @Override
+        public String getAttributeValue(Object o, String namespaceURI, String attrName) {
+            Element e = (Element) o;
+            if (namespaceURI == null || namespaceURI.isEmpty()) {
+                return getAttributeValue(o, attrName);
+            }
+            return e.hasAttributeNS(namespaceURI, attrName) ? e.getAttributeNS(namespaceURI, attrName) : null;
+        }
+
+        @Override public String getClass(Object e) { return getAttributeValue(e, "class"); }
+        @Override public String getID(Object e) { return getAttributeValue(e, "id"); }
+        @Override public String getNonCssStyling(Object e) { return null; }
+        @Override public String getElementStyling(Object e) { return null; }
+        @Override public String getLang(Object e) { return null; }
+        @Override public boolean isLink(Object e) { return false; }
+        @Override public boolean isVisited(Object e) { return false; }
+        @Override public boolean isHover(Object e) { return false; }
+        @Override public boolean isActive(Object e) { return false; }
+        @Override public boolean isFocus(Object e) { return false; }
+        @Override public boolean isMarker(Object e) { return false; }
+    }
+}


### PR DESCRIPTION
Fixes #191. Follow-up to #176 / #177: the fast reject makes each selector
check cheap, but `mapChild` still visits every selector for every element.
This PR makes each element visit only the selectors that can match it.

## How it works

- Each selector list (a Mapper's `axes`) is indexed once by each selector's own simple selector: by id if it has one, else by first class, else by element name. Selectors with none of these (and attribute or pseudo-class only selectors) go to a universal bucket that is always visited.
- Buckets store positions in the list. For an element, the candidates are the universal bucket plus the buckets for its name, id and class tokens, concatenated and sorted. Since every selector is in exactly one bucket, there are no duplicates, and ascending positions are a subsequence of the original scan, so the cascade order cannot change.
- The bucket lookup can only skip selectors that `mayMatch` (#177) would reject, so correctness reduces to the fast-reject semantics that are already in place.
- `mapChild` also built the child axes as a side effect of scanning everything. That part is reconstructed explicitly: the descendant carry-forward list is precomputed once per index and shared, and activated chained selectors are spliced in at their producers' positions, lazily, only when a child Mapper maps children of its own. On ties the carried producer comes before its chain, as in the original loop.
- Indexes are cached per selector list identity. When every selector is descendant-axis (the common case), the carry-forward list is the indexed list itself, so the whole descendant cone of the document shares one index.

## Numbers

Measured on Orbeon documents (about 11k selectors), on top of #177:

| Document | layout before | layout after |
|---|---|---|
| benchmark fixture | 1074 ms | 222 ms (4.8x) |
| 192 page form | 10.7 s | 0.7 s |
| small 5 page document | 347 ms | 232 ms |

Output is pixel-identical on all pages.

## Tests

- Element-level tests: bucket routing for each bucket kind, cascade order across buckets in both declaration orders, multi-class selectors, descendant vs child chains, chain splice ordering, sibling selectors, pseudo-elements, `:first-child` inside a class bucket, more than 8 chains activated by one element (array growth), and an exact list-level assertion of the merged child axes (verified to fail if the merge tie-break is changed).
- A seeded differential test: 40 random documents, every element compared against a naive reference matcher that evaluates each selector chain by walking the DOM, over a stylesheet covering all selector kinds.
- Core and visual/non-visual regression suites pass.
