### PR TITLE
Fix #193: emit link annotation /Contents for block image links

### DIFF
--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -31,6 +31,7 @@ import org.apache.pdfbox.pdmodel.*;
 import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
@@ -1645,6 +1646,182 @@ public class NonVisualRegressionTest {
             }
         }
         assertTrue("Karla must be selected when CSS font-family is lowercase 'karla'", karlaEmbedded);
+    }
+
+    /**
+     * A block-level link whose only child is an image (with the anchor markup
+     * spread across several indented lines, so the anchor's text content is
+     * whitespace only) must still get an annotation /Contents so PDF/UA-1
+     * (ISO 14289-1 clause 7.18) is satisfied. The accessible name comes from
+     * the image's alt text.
+     */
+    @Test
+    public void testBlockImageLinkAnnotationHasContents() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Block Image Link Test</title>" +
+            "<meta name='description' content='Test block image link contents'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            ".linkblock a { display: block; }" +
+            ".linkblock img { display: block; }" +
+            "</style></head><body>" +
+            "<div class='linkblock'>\n" +
+            "  <a href='https://www.example.com/target'>\n" +
+            "    <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='Banner: apply for an assessment' style='width:50px;height:20px;'/>\n" +
+            "  </a>\n" +
+            "</div>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDAnnotationLink link = linkAnnotationForUri(doc, 0, "https://www.example.com/target");
+            assertNotNull("Should find a link annotation", link);
+            assertNotNull("Block image link annotation must have /Contents", link.getContents());
+            assertThat(link.getContents(), equalTo("Banner: apply for an assessment"));
+        }
+    }
+
+    /**
+     * A link with neither text, title, nor a usable image alt (the anchor's
+     * text is whitespace only) must fall back to the URI for its annotation
+     * /Contents rather than being left without one.
+     */
+    @Test
+    public void testImageLinkWithoutAltFallsBackToUri() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Image Link Uri Fallback Test</title>" +
+            "<meta name='description' content='Test image link uri fallback'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "a, img { display: block; }" +
+            "</style></head><body>" +
+            "<div>\n" +
+            "  <a href='https://www.example.com/fallback'>\n" +
+            "    <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='' style='width:50px;height:20px;'/>\n" +
+            "  </a>\n" +
+            "</div>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDAnnotationLink link = linkAnnotationForUri(doc, 0, "https://www.example.com/fallback");
+            assertNotNull("Should find a link annotation", link);
+            assertThat(link.getContents(), equalTo("https://www.example.com/fallback"));
+        }
+    }
+
+    /**
+     * A non-breaking space between the anchor and its child image is layout
+     * filler, not an accessible name: it must not shadow the image alt.
+     * {@code String.trim()} does not strip U+00A0, so this exercises the
+     * dedicated blank-handling in setLinkAnnotationContents.
+     */
+    @Test
+    public void testImageLinkWithNbspTextUsesAlt() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Nbsp Image Link Test</title>" +
+            "<meta name='description' content='Test nbsp image link contents'/>" +
+            "<style>body { margin: 0; font-family: 'TestFont'; font-size: 12px; }</style>" +
+            "</head><body>" +
+            "<div><a href='https://www.example.com/nbsp'>&#160;" +
+            "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' " +
+            "alt='Banner: apply for an assessment' style='width:50px;height:20px;'/></a></div>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDAnnotationLink link = linkAnnotationForUri(doc, 0, "https://www.example.com/nbsp");
+            assertNotNull("Should find a link annotation", link);
+            assertThat(link.getContents(), equalTo("Banner: apply for an assessment"));
+        }
+    }
+
+    /**
+     * Guards 1.1.58 behaviour: a plain inline text link keeps its visible text
+     * as the annotation /Contents (title still wins when present).
+     */
+    @Test
+    public void testInlineTextLinkContentsPreserved() throws IOException {
+        String html =
+            "<html lang='en'><head>" +
+            "<title>Inline Text Link Test</title>" +
+            "<meta name='description' content='Test inline text link contents'/>" +
+            "<style>body { margin: 0; font-family: 'TestFont'; font-size: 12px; }</style>" +
+            "</head><body>" +
+            "<p><a href='https://www.example.com/text'>Visible link text</a></p>" +
+            "<p><a href='https://www.example.com/titled' title='Title wins'>Some text</a></p>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDAnnotationLink textLink = linkAnnotationForUri(doc, 0, "https://www.example.com/text");
+            assertNotNull(textLink);
+            assertThat(textLink.getContents(), equalTo("Visible link text"));
+
+            PDAnnotationLink titledLink = linkAnnotationForUri(doc, 0, "https://www.example.com/titled");
+            assertNotNull(titledLink);
+            assertThat(titledLink.getContents(), equalTo("Title wins"));
+        }
+    }
+
+    /**
+     * The link annotation on the given page whose URI action targets {@code uri},
+     * or {@code null} if there is none. Identifying links by URI rather than by
+     * annotation index avoids depending on annotation ordering, which is not
+     * stable in general (e.g. image-map areas iterate a HashMap).
+     */
+    private static PDAnnotationLink linkAnnotationForUri(PDDocument doc, int page, String uri) throws IOException {
+        for (PDAnnotation a : doc.getPage(page).getAnnotations()) {
+            if (a instanceof PDAnnotationLink) {
+                PDAnnotationLink link = (PDAnnotationLink) a;
+                if (link.getAction() instanceof PDActionURI
+                        && uri.equals(((PDActionURI) link.getAction()).getURI())) {
+                    return link;
+                }
+            }
+        }
+        return null;
     }
 
     // TODO:

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxFastLinkManager.java
@@ -34,6 +34,8 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDBorderStyleDictionary;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.destination.PDPageXYZDestination;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import java.awt.*;
 import java.awt.geom.*;
@@ -291,22 +293,67 @@ public class PdfBoxFastLinkManager {
 
     /**
      * Set the link annotation's /Contents entry so PDF/UA-1 (ISO 14289-1
-     * clause 7.18.5) is satisfied. Prefers the element's `title` attribute,
-     * falls back to the visible text, then to the URI itself, so every
-     * link annotation has an alternate description.
+     * clause 7.18) is satisfied. Prefers the element's `title` attribute,
+     * falls back to the visible text, then to the `alt` of a descendant image
+     * (for image-only links, whose accessible name lives on the image), and
+     * finally to the URI itself, so every link annotation has an alternate
+     * description.
+     * <p>
+     * Each candidate is trimmed before it is considered, so an anchor whose
+     * only "text" is layout whitespace (e.g. newlines and indentation around a
+     * block-level child image) does not shadow the later fallbacks.
      */
     private static void setLinkAnnotationContents(PDAnnotationLink annot, Element elem, String uri) {
-        String contents = elem.getAttribute("title");
-        if (contents == null || contents.isEmpty()) {
-            contents = elem.getTextContent();
+        // Nested (rather than a varargs helper) so the later candidates - in
+        // particular firstImageAlt, which forces a deep DOM traversal - are only
+        // computed when the earlier, cheaper ones did not already win.
+        String contents = nonBlank(elem.getAttribute("title"));
+        if (contents == null) {
+            contents = nonBlank(elem.getTextContent());
         }
-        if (contents == null || contents.isEmpty()) {
-            contents = uri;
+        if (contents == null) {
+            contents = nonBlank(firstImageAlt(elem));
         }
-        contents = contents.trim();
-        if (!contents.isEmpty()) {
+        if (contents == null) {
+            contents = nonBlank(uri);
+        }
+        if (contents != null) {
             annot.setContents(contents);
         }
+    }
+
+    /**
+     * Return the candidate trimmed, or {@code null} if it is null or blank.
+     * Besides the ASCII whitespace {@link String#trim()} removes, a non-breaking
+     * space (U+00A0) is treated as blank: it is common as layout filler around a
+     * block-level child image, yet {@code trim()} (which only strips chars
+     * &lt;= U+0020) would leave it behind and let it shadow the later fallbacks.
+     */
+    private static String nonBlank(String candidate) {
+        if (candidate == null) {
+            return null;
+        }
+        String trimmed = candidate.replace('\u00A0', ' ').trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * The `alt` text of the first descendant image that carries one, or
+     * {@code null}. This is the accessible name of an image-only link, matching
+     * the description the engine puts on the image's /Figure structure element.
+     */
+    private static String firstImageAlt(Element elem) {
+        NodeList images = elem.getElementsByTagName("img");
+        for (int i = 0; i < images.getLength(); i++) {
+            Node image = images.item(i);
+            if (image instanceof Element) {
+                String alt = ((Element) image).getAttribute("alt");
+                if (alt != null && !alt.trim().isEmpty()) {
+                    return alt;
+                }
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixes #193.

A block-level `<a>` whose only child is an `<img>`, with the anchor markup on separate indented lines, produced a `PDAnnotationLink` with no `/Contents`, violating PDF/UA-1 §7.18.

`setLinkAnnotationContents` skipped the URI fallback whenever the anchor's text was non-empty, then trimmed it away before the emptiness check — so whitespace-only text (indentation around a block child image) left the annotation with no description at all.

**Change:** trim each candidate before use, and add the descendant image's `alt` as an explicit fallback: `title → text → image alt → URI`. The image `alt` matches the description already put on the image's `/Figure` structure element.

**Tests** (`openhtmltopdf-examples`, `NonVisualRegressionTest`):
- `testBlockImageLinkAnnotationHasContents` — the reported shape now gets the image `alt`.
- `testImageLinkWithoutAltFallsBackToUri` — no text/title/alt falls back to the URI.
- `testInlineTextLinkContentsPreserved` — guards 1.1.58 text/title behaviour.

First two fail on `main`, all pass after the fix. Annotation-metadata only — no visual-regression impact.
