### PR TITLE
Add contributing guide and PR template asking about AI assistance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,8 @@
 <summary>Why we ask</summary>
 
 Relaying review notes into a code generator and waiting for a regenerated patch
-is slow for everyone. When we know a change is AI-assisted and we have your
-permission to push, we usually just fix the small stuff ourselves and merge.
+is time consuming for everyone. When we know a change is AI-assisted and we have
+your permission to push, we usually just fix the small stuff ourselves and merge.
 
 Pushing needs GitHub's *Allow edits by maintainers*, which is on by default for
 pull requests from forks. Either answer is fine — it is knowing which that

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## What does this change?
+
+<!-- Short description. Link the issue if there is one: Fixes #123 -->
+
+## How was it written?
+
+<!-- Tick one. AI-assisted PRs are welcome — see "Why we ask" below. -->
+
+- [ ] Written by hand
+- [ ] AI-assisted — I have read and understood every line
+- [ ] Largely AI-generated
+
+- [ ] I can answer follow-up questions about how this change works
+
+## How should we send you fixes?
+
+- [ ] Push small fixes straight to my branch — I will see the commits and can object
+- [ ] Leave them as review comments and I will make the changes
+
+---
+
+<details>
+<summary>Why we ask</summary>
+
+Relaying review notes into a code generator and waiting for a regenerated patch
+is slow for everyone. When we know a change is AI-assisted and we have your
+permission to push, we usually just fix the small stuff ourselves and merge.
+
+Pushing needs GitHub's *Allow edits by maintainers*, which is on by default for
+pull requests from forks. Either answer is fine — it is knowing which that
+saves the round trip.
+
+</details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to openhtmltopdf
+
+Thanks for helping out. Bug reports, test cases and pull requests are all
+welcome.
+
+## Pull requests
+
+- Branch off `main` and open the pull request against `main`.
+- Run the test suite locally before pushing: `mvn test`.
+- Include a test for the behaviour you changed. Rendering changes usually
+  belong in `openhtmltopdf-examples` — see the visual and non-visual
+  regression tests there for the pattern.
+- Keep the change focused. A pull request that fixes one thing is reviewed and
+  merged far faster than one that fixes three.
+
+Every merge to `main` publishes a release, so fixes and their tests should land
+together in a single pull request rather than as follow-ups.
+
+## AI-assisted contributions
+
+We accept pull requests written with AI assistance, and we use it ourselves.
+We ask two things in the pull request description: say that AI was involved,
+and say whether we may push fixes directly to your branch.
+
+Neither is a restriction. It changes how we review: for an AI-assisted change
+where we may push, we tend to correct small things ourselves and merge, instead
+of opening a review round that has to travel back through a code generator.
+
+If you use AI, please still:
+
+- read and understand the diff you are submitting;
+- run the test suite locally (`mvn test`);
+- include a test for the behaviour you changed;
+- be around to answer questions about the change.
+
+That last point is the one that matters most. The usual problem with an
+AI-generated pull request is not the code — it is an author who cannot say why
+it works or confirm that it does.
+
+## Reporting bugs
+
+A self-contained HTML file that reproduces the problem is worth more than any
+description of it. Please say which version of openhtmltopdf you are using and
+what you expected the output to look like.


### PR DESCRIPTION
Contributors are asked to state whether a change was AI-assisted and whether maintainers may push fixes directly to the branch.

Every review round costs maintainer attention, and routing one back through a generator is rarely necessary when the correction could just be pushed.
Knowing both answers up front lets small fixes land directly instead.

What do you think about that?