### PR TITLE
Add support for CSS Custom Properties (CSS Variables) (#114)

### DIFF
--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/CascadedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/CascadedStyle.java
@@ -33,6 +33,7 @@ import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.PropertyValue;
 import com.openhtmltopdf.css.sheet.CustomPropertyDeclaration;
+import com.openhtmltopdf.css.sheet.PendingVarPropertyDeclaration;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 
@@ -82,6 +83,15 @@ public class CascadedStyle {
 
     /** Next rank to assign; increases monotonically across {@link #addProperties}. */
     private int nextSequence;
+
+    /**
+     * Whether any declaration added here was a {@link PendingVarPropertyDeclaration}.
+     * Only then does the order in which declarations are derived matter, so this
+     * keeps documents that use no CSS variables off the ordering path entirely.
+     * It stays set if such a declaration is later overwritten by a plain one,
+     * which costs an unnecessary sort but is never wrong.
+     */
+    private boolean hasPendingVarProperties;
 
     private String fingerprint;
     
@@ -163,6 +173,7 @@ public class CascadedStyle {
         customProperties = new TreeMap<>(startingPoint.customProperties);
         matchSequence = new HashMap<>(startingPoint.matchSequence);
         nextSequence = startingPoint.nextSequence;
+        hasPendingVarProperties = startingPoint.hasPendingVarProperties;
 
         addProperties(props);
     }
@@ -218,6 +229,9 @@ public class CascadedStyle {
                 // Record cascade priority: entries are visited in ascending
                 // priority, so a later put means higher priority.
                 matchSequence.put(prop.getCSSName(), nextSequence++);
+                if (prop instanceof PendingVarPropertyDeclaration) {
+                    hasPendingVarProperties = true;
+                }
             }
         }
     }
@@ -329,6 +343,16 @@ public class CascadedStyle {
     public int getMatchSequence(CSSName cssName) {
         Integer seq = matchSequence.get(cssName);
         return seq == null ? Integer.MIN_VALUE : seq.intValue();
+    }
+
+    /**
+     * Whether this style carries a declaration whose value contains {@code var()}
+     * and therefore has to be derived in cascade order.
+     *
+     * @see #hasPendingVarProperties
+     */
+    public boolean hasPendingVarProperties() {
+        return hasPendingVarProperties;
     }
 
     public int countAssigned() { return cascadedProperties.size(); }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/CascadedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/CascadedStyle.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.css.newmatch;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.PropertyValue;
+import com.openhtmltopdf.css.sheet.CustomPropertyDeclaration;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 
@@ -61,6 +63,26 @@ public class CascadedStyle {
      */
     private final Map<CSSName, PropertyDeclaration> cascadedProperties;
 
+    /**
+     * Map of CSS custom property ({@code --*}) declarations, keyed by name.
+     * Custom properties are not {@link CSSName}s, so they cascade separately.
+     * A {@link TreeMap} is used so iteration order (and thus the fingerprint)
+     * is deterministic.
+     */
+    private final Map<String, CustomPropertyDeclaration> customProperties;
+
+    /**
+     * Cascade-priority rank per {@link CSSName} (higher = higher priority),
+     * assigned in {@link #addProperties} as declarations are applied in
+     * ascending-priority order. Lets {@code CalculatedStyle.derive()} order a
+     * var()-bearing shorthand against an explicit longhand it expands into, which
+     * the per-CSSName cascade cannot.
+     */
+    private final Map<CSSName, Integer> matchSequence;
+
+    /** Next rank to assign; increases monotonically across {@link #addProperties}. */
+    private int nextSequence;
+
     private String fingerprint;
     
     /**
@@ -79,6 +101,20 @@ public class CascadedStyle {
         this();
 
         addProperties(iter);
+    }
+
+    /**
+     * As {@link #CascadedStyle(Iterator)} but also captures CSS custom property
+     * ({@code --*}) declarations, given in order of specificity.
+     *
+     * @param iter        PropertyDeclarations in order of specificity.
+     * @param customDecls custom property declarations in order of specificity.
+     */
+    CascadedStyle(java.util.Iterator<PropertyDeclaration> iter, List<CustomPropertyDeclaration> customDecls) {
+        this();
+
+        addProperties(iter);
+        addCustomProperties(customDecls);
     }
     
     /**
@@ -124,6 +160,9 @@ public class CascadedStyle {
 
     private CascadedStyle(CascadedStyle startingPoint, Iterator<PropertyDeclaration> props) {
         cascadedProperties = new TreeMap<>(startingPoint.cascadedProperties);
+        customProperties = new TreeMap<>(startingPoint.customProperties);
+        matchSequence = new HashMap<>(startingPoint.matchSequence);
+        nextSequence = startingPoint.nextSequence;
 
         addProperties(props);
     }
@@ -135,6 +174,8 @@ public class CascadedStyle {
      */
     private CascadedStyle() {
         cascadedProperties = new TreeMap<>();
+        customProperties = new TreeMap<>();
+        matchSequence = new HashMap<>();
     }
 
     /**
@@ -174,8 +215,53 @@ public class CascadedStyle {
 				continue;
             for (PropertyDeclaration prop : bucket) {
                 cascadedProperties.put(prop.getCSSName(), prop);
+                // Record cascade priority: entries are visited in ascending
+                // priority, so a later put means higher priority.
+                matchSequence.put(prop.getCSSName(), nextSequence++);
             }
         }
+    }
+
+    /**
+     * Cascades CSS custom property declarations into {@link #customProperties},
+     * keyed by name. Uses the same bucket-sort on importance and origin as
+     * {@link #addProperties(Iterator)}; the input is already in order of
+     * specificity.
+     */
+    private void addCustomProperties(List<CustomPropertyDeclaration> decls) {
+        if (decls.isEmpty()) {
+            return;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<CustomPropertyDeclaration>[] buckets =
+                new java.util.List[PropertyDeclaration.IMPORTANCE_AND_ORIGIN_COUNT];
+
+        for (CustomPropertyDeclaration decl : decls) {
+            List<CustomPropertyDeclaration> bucket = buckets[decl.getImportanceAndOrigin()];
+            if (bucket == null) {
+                bucket = new ArrayList<>();
+                buckets[decl.getImportanceAndOrigin()] = bucket;
+            }
+            bucket.add(decl);
+        }
+
+        for (List<CustomPropertyDeclaration> bucket : buckets) {
+            if (bucket == null)
+                continue;
+            for (CustomPropertyDeclaration decl : bucket) {
+                customProperties.put(decl.getName(), decl);
+            }
+        }
+    }
+
+    /**
+     * The cascaded custom property ({@code --*}) declarations for this style,
+     * keyed by name. The values may still contain {@code var()} references; they
+     * are resolved per element at computed-value time.
+     */
+    public Map<String, CustomPropertyDeclaration> getCustomProperties() {
+        return customProperties;
     }
 
     /**
@@ -233,12 +319,30 @@ public class CascadedStyle {
         return cascadedProperties.values();
     }
 
+    /**
+     * Cascade-priority rank of {@code cssName}'s winning declaration (higher
+     * wins); {@link Integer#MIN_VALUE} if unknown. Used to derive declarations in
+     * priority order.
+     *
+     * @see #matchSequence
+     */
+    public int getMatchSequence(CSSName cssName) {
+        Integer seq = matchSequence.get(cssName);
+        return seq == null ? Integer.MIN_VALUE : seq.intValue();
+    }
+
     public int countAssigned() { return cascadedProperties.size(); }
 
     public String getFingerprint() {
         if (this.fingerprint == null) {
             StringBuilder sb = new StringBuilder();
             for (PropertyDeclaration o : cascadedProperties.values()) {
+                sb.append(o.getFingerprint());
+            }
+            // Custom properties must contribute too: identical regular declarations
+            // but different --* values can resolve var() differently, so two such
+            // elements must not share a cached style.
+            for (CustomPropertyDeclaration o : customProperties.values()) {
                 sb.append(o.getFingerprint());
             }
             this.fingerprint = sb.toString();

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Condition.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Condition.java
@@ -137,6 +137,15 @@ abstract class Condition {
     static Condition createFirstChildCondition() {
         return new FirstChildCondition();
     }
+
+    /**
+     * the CSS condition that element has pseudo-class :root (the document root)
+     *
+     * @return Returns
+     */
+    static Condition createRootCondition() {
+        return new RootCondition();
+    }
     
     /**
      * the CSS condition that element has pseudo-class :last-child
@@ -487,6 +496,23 @@ abstract class Condition {
         @Override
         void toCSS(StringBuilder sb) {
             sb.append(":first-child");
+        }
+    }
+
+    private static class RootCondition extends Condition {
+
+        RootCondition() {
+        }
+
+        @Override
+        boolean matches(Object e, AttributeResolver attRes, TreeResolver treeRes) {
+            // The root element is the one without a parent element.
+            return treeRes.getParentElement(e) == null;
+        }
+
+        @Override
+        void toCSS(StringBuilder sb) {
+            sb.append(":root");
         }
     }
     

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Matcher.java
@@ -756,26 +756,30 @@ public class Matcher {
             Ruleset nonCssStyling = getNonCssStyle(e);
 
             List<PropertyDeclaration> propList = new ArrayList<>();
+            List<CustomPropertyDeclaration> customPropList = new ArrayList<>();
 
             // Specificity 0,0,0,0
             if (nonCssStyling != null) {
                 propList.addAll(nonCssStyling.getPropertyDeclarations());
+                customPropList.addAll(nonCssStyling.getCustomPropertyDeclarations());
             }
 
             // These should have been returned in order of specificity
             for (Selector sel : mappedSelectors) {
                 propList.addAll(sel.getRuleset().getPropertyDeclarations());
+                customPropList.addAll(sel.getRuleset().getCustomPropertyDeclarations());
             }
 
             // Specificity 1,0,0,0
             if (elementStyling != null) {
                 propList.addAll(elementStyling.getPropertyDeclarations());
+                customPropList.addAll(elementStyling.getCustomPropertyDeclarations());
             }
 
-            if (propList.isEmpty()) {
+            if (propList.isEmpty() && customPropList.isEmpty()) {
                 return CascadedStyle.emptyCascadedStyle;
             } else {
-                return new CascadedStyle(propList.iterator());
+                return new CascadedStyle(propList.iterator(), customPropList);
             }
         }
 
@@ -795,15 +799,17 @@ public class Matcher {
             }
 
             List<PropertyDeclaration> propList = new ArrayList<>();
+            List<CustomPropertyDeclaration> customPropList = new ArrayList<>();
 
             for (Selector sel : pe) {
                 propList.addAll(sel.getRuleset().getPropertyDeclarations());
+                customPropList.addAll(sel.getRuleset().getCustomPropertyDeclarations());
             }
 
-            if (propList.isEmpty()) {
+            if (propList.isEmpty() && customPropList.isEmpty()) {
                 return CascadedStyle.emptyCascadedStyle;
             } else {
-                return new CascadedStyle(propList.iterator());
+                return new CascadedStyle(propList.iterator(), customPropList);
             }
         }
     }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/newmatch/Selector.java
@@ -219,6 +219,14 @@ public class Selector {
         _specificityC++;
         addCondition(Condition.createFirstChildCondition());
     }
+
+    /**
+     * the CSS condition that element has pseudo-class :root (the document root)
+     */
+    public void addRootCondition() {
+        _specificityC++;
+        addCondition(Condition.createRootCondition());
+    }
     
     /**
      * the CSS condition that element has pseudo-class :last-child

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -1731,7 +1731,13 @@ public class CSSParser {
                 throw new CSSParseException(t, Token.TK_RPAREN, getCurrentLine());
             }
 
-            if (f.equals("rgb(") || f.equals("rgba(")) {
+            if (CSSValueText.containsVarFunction(params)) {
+                // A parameter references a custom property, so the function
+                // cannot be evaluated yet. Keep it as a generic function; the
+                // whole declaration becomes pending and is re-parsed (and then
+                // evaluated here) once the var() references are substituted.
+                result = new PropertyValue(new FSFunction(f.substring(0, f.length() - 1), params));
+            } else if (f.equals("rgb(") || f.equals("rgba(")) {
                 result = new PropertyValue(createRGBColorFromFunction(params));
             } else if (f.equals("hsl(") || f.equals("hsla(")) {
                 result = new PropertyValue(createRGBColorFromHSLFunction(params));

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSParser.java
@@ -788,7 +788,8 @@ public class CSSParser {
             }
 
             if (!ruleset.getPropertyDeclarations().isEmpty() ||
-                    !ruleset.getInvalidPropertyDeclarations().isEmpty()) {
+                    !ruleset.getInvalidPropertyDeclarations().isEmpty() ||
+                    !ruleset.getCustomPropertyDeclarations().isEmpty()) {
                 container.addContent(ruleset);
             }
         } catch (CSSParseException e) {
@@ -1173,6 +1174,8 @@ public class CSSParser {
             selector.setPseudoClass(Selector.ACTIVE_PSEUDOCLASS);
         } else if (value.equals("first-child")) {
             selector.addFirstChildCondition();
+        } else if (value.equals("root")) {
+            selector.addRootCondition();
         } else if (value.equals("even")) {
             selector.addEvenChildCondition();
         } else if (value.equals("odd")) {
@@ -1307,11 +1310,30 @@ public class CSSParser {
         //System.out.println("declaration()");
         try {
             Token t = nextWithSave();
-            if (t == Token.TK_IDENT) {
-                String propertyName = property();
-                CSSName cssName = CSSName.getByPropertyName(propertyName);
+            {
+                String propertyName;
+                if (t == Token.TK_IDENT) {
+                    propertyName = property();
+                } else if (t == Token.TK_MINUS) {
+                    // A CSS custom property name ("--foo"). The lexer splits the
+                    // leading "--" into a MINUS token followed by an IDENT, so
+                    // rejoin them here.
+                    propertyName = customPropertyName();
+                    if (propertyName == null) {
+                        throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
+                    }
+                } else {
+                    throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
+                }
 
-                boolean valid = checkCSSName(cssName, propertyName);
+                // A "--" property is a custom property: author-defined (not a
+                // CSSName) and resolved per element at compute time, so we don't
+                // look it up or warn here.
+                boolean customProperty = propertyName.startsWith("--");
+
+                CSSName cssName = customProperty ? null : CSSName.getByPropertyName(propertyName);
+
+                boolean valid = !customProperty && checkCSSName(cssName, propertyName);
 
                 t = next();
                 if (t == Token.TK_COLON) {
@@ -1338,7 +1360,17 @@ public class CSSParser {
                                 getCurrentLine());
                     }
 
-                    if (valid) {
+                    if (customProperty) {
+                        ruleset.addCustomProperty(
+                                new CustomPropertyDeclaration(
+                                        propertyName, CSSValueText.toCSS(values), important, ruleset.getOrigin()));
+                    } else if (valid && CSSValueText.containsVarFunction(values)) {
+                        // Defer validation/building: the value references custom
+                        // properties only resolvable per element at compute time.
+                        ruleset.addProperty(
+                                new PendingVarPropertyDeclaration(
+                                        cssName, CSSValueText.toCSS(values), important, ruleset.getOrigin()));
+                    } else if (valid) {
                         if (cssName == CSSName.FS_NAMED_DESTINATION && values.stream().anyMatch(propertyValue -> IdentValue.valueOf(propertyValue.getStringValue()) == IdentValue.CREATE)) {
                             ThreadCtx.get().sharedContext().setUsingFsNamedDestination(true);
                         }
@@ -1362,13 +1394,36 @@ public class CSSParser {
                     save(t);
                     throw new CSSParseException(t, Token.TK_COLON, getCurrentLine());
                 }
-            } else {
-                throw new CSSParseException(t, Token.TK_IDENT, getCurrentLine());
             }
         } catch (CSSParseException e) {
             error(e, "declaration", true);
             recover(false, true);
         }
+    }
+
+    /**
+     * Reads a CSS custom property name ("--foo") when the leading "--" has been
+     * lexed as a MINUS token (already consumed/saved). The lexer tokenizes
+     * "--foo" as MINUS followed by IDENT("-foo"); this rejoins them, preserving
+     * case (custom property names are case-sensitive). Returns {@code null} if
+     * what follows is not a custom property name.
+     *
+     * <p>A spec-compliant tokenizer would lex "--foo" as a single ident; that
+     * would remove this rejoin (and the matching one in {@code function()}) but
+     * needs the JFlex lexer regenerated, so we handle it in the parser.</p>
+     */
+    private String customPropertyName() throws IOException {
+        next(); // consume the leading MINUS (saved by the caller)
+        Token t = next();
+        if (t == Token.TK_IDENT) {
+            String identText = getTokenValue(t, true);
+            if (identText.startsWith("-")) {
+                skip_whitespace();
+                return "-" + identText;
+            }
+        }
+        save(t);
+        return null;
     }
 
     //  expr
@@ -1484,7 +1539,9 @@ public class CSSParser {
         //System.out.println("term()");
         float sign = 1;
         Token t = nextWithSave();
+        boolean minusConsumed = false;
         if (t == Token.TK_PLUS || t == Token.TK_MINUS) {
+            minusConsumed = t == Token.TK_MINUS;
             sign = unary_operator();
             t = nextWithSave();
         }
@@ -1613,8 +1670,17 @@ public class CSSParser {
                 next();
                 skip_whitespace();
                 break;
-            case Token.IDENT:
-                String value = getTokenValue(t, literal);
+            case Token.IDENT: {
+                String value;
+                String caseSensitive = getTokenValue(t, true);
+                if (minusConsumed && caseSensitive.startsWith("-")) {
+                    // A custom property reference such as "--foo" (e.g. inside
+                    // var(--foo)). The lexer split the leading "--" into a MINUS
+                    // and an IDENT("-foo"); rejoin, preserving case.
+                    value = "-" + caseSensitive;
+                } else {
+                    value = getTokenValue(t, literal);
+                }
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_IDENT,
                         value,
@@ -1622,6 +1688,7 @@ public class CSSParser {
                 next();
                 skip_whitespace();
                 break;
+            }
             case Token.URI:
                 result = new PropertyValue(
                         CSSPrimitiveValue.CSS_URI,

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSValueText.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSValueText.java
@@ -1,0 +1,105 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2024 openhtmltopdf contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package com.openhtmltopdf.css.parser;
+
+import java.util.List;
+
+/**
+ * Reconstructs the CSS text of a parsed value (a list of {@link PropertyValue}
+ * terms), preserving the comma/slash/space operators between terms and recursing
+ * into function arguments and value lists.
+ *
+ * <p>Unlike {@link FSFunction#toString()} it keeps comma- vs space-separated
+ * arguments distinct, which matters when the text is re-parsed (custom property
+ * values and {@code var()} fallbacks): {@code var(--x, 1px solid red)} must not
+ * collapse to {@code var(--x,1px,solid,red)}.</p>
+ *
+ * <p>This generalizes the value joining in {@code InvalidPropertyDeclaration.toCSS},
+ * which is comma/space-only and non-recursive (so it can't faithfully serialize
+ * inside functions).</p>
+ */
+public final class CSSValueText {
+    private CSSValueText() {}
+
+    /**
+     * Serializes a list of value terms back to CSS text suitable for re-parsing.
+     */
+    public static String toCSS(List<PropertyValue> values) {
+        StringBuilder sb = new StringBuilder();
+        appendValues(sb, values);
+        return sb.toString();
+    }
+
+    /**
+     * Returns true if any term in the value (recursively, including function
+     * arguments and nested lists) is a {@code var()} function.
+     */
+    public static boolean containsVarFunction(List<PropertyValue> values) {
+        for (PropertyValue value : values) {
+            if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_FUNCTION &&
+                    value.getFunction() != null) {
+                if ("var".equalsIgnoreCase(value.getFunction().getName())) {
+                    return true;
+                }
+                if (containsVarFunction(value.getFunction().getParameters())) {
+                    return true;
+                }
+            } else if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_LIST) {
+                if (containsVarFunction(value.getValues())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void appendValues(StringBuilder sb, List<PropertyValue> values) {
+        boolean first = true;
+        for (PropertyValue value : values) {
+            if (!first) {
+                Token op = value.getOperator();
+                if (op == Token.TK_COMMA) {
+                    sb.append(", ");
+                } else if (op == Token.TK_VIRGULE) {
+                    sb.append(" / ");
+                } else {
+                    sb.append(' ');
+                }
+            }
+            appendValue(sb, value);
+            first = false;
+        }
+    }
+
+    private static void appendValue(StringBuilder sb, PropertyValue value) {
+        if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_FUNCTION &&
+                value.getFunction() != null) {
+            FSFunction function = value.getFunction();
+            sb.append(function.getName());
+            sb.append('(');
+            appendValues(sb, function.getParameters());
+            sb.append(')');
+        } else if (value.getPropertyValueType() == PropertyValue.VALUE_TYPE_LIST) {
+            appendValues(sb, value.getValues());
+        } else {
+            sb.append(value.getCssText());
+        }
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSVariableSubstitution.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSVariableSubstitution.java
@@ -136,30 +136,30 @@ public final class CSSVariableSubstitution {
     }
 
     /**
-     * Finds the next {@code var(} that begins a function token (i.e. not part of
-     * a longer identifier such as {@code sidebar(}), starting at {@code start}.
+     * Finds the next {@code var(} that begins a function token, starting at
+     * {@code start}. It must not be part of a longer identifier (e.g.
+     * {@code sidebar(}) nor lie inside a quoted string: a string token is opaque,
+     * so {@code var(} within it is literal text, not a reference (matching the
+     * quote-awareness of {@link #matchingParen}/{@link #topLevelComma}).
      * Returns the index of the {@code v}, or -1.
      */
     private static int indexOfVar(String s, int start) {
-        int i = start;
-        while (true) {
-            int idx = indexOfIgnoreCase(s, "var(", i);
-            if (idx < 0) {
-                return -1;
-            }
-            char prev = idx == 0 ? '\0' : s.charAt(idx - 1);
-            if (!isIdentChar(prev)) {
-                return idx;
-            }
-            i = idx + 1;
-        }
-    }
-
-    private static int indexOfIgnoreCase(String s, String needle, int from) {
-        int max = s.length() - needle.length();
-        for (int i = Math.max(from, 0); i <= max; i++) {
-            if (s.regionMatches(true, i, needle, 0, needle.length())) {
-                return i;
+        char quote = 0;
+        for (int i = Math.max(start, 0); i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (quote != 0) {
+                if (c == '\\') {
+                    i++; // skip escaped char
+                } else if (c == quote) {
+                    quote = 0;
+                }
+            } else if (c == '"' || c == '\'') {
+                quote = c;
+            } else if ((c == 'v' || c == 'V') && s.regionMatches(true, i, "var(", 0, 4)) {
+                char prev = i == 0 ? '\0' : s.charAt(i - 1);
+                if (!isIdentChar(prev)) {
+                    return i;
+                }
             }
         }
         return -1;

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSVariableSubstitution.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/parser/CSSVariableSubstitution.java
@@ -1,0 +1,228 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2024 openhtmltopdf contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package com.openhtmltopdf.css.parser;
+
+/**
+ * Substitutes CSS {@code var()} references in a value string with resolved custom
+ * property values, following the
+ * <a href="https://www.w3.org/TR/css-variables-1/#substitute-a-var">CSS Variables
+ * substitution algorithm</a> textually. It is paren- and quote-aware (so nested
+ * {@code var()} and parens/commas inside strings work, which a regex cannot do);
+ * a {@link VarResolver} supplies replacements and fallbacks are substituted
+ * recursively.
+ *
+ * <p>The {@link Result} reports whether substitution fully succeeded. If a
+ * reference is undefined with no fallback, the value is "invalid at
+ * computed-value time" and the caller should treat the property as {@code unset}.</p>
+ */
+public final class CSSVariableSubstitution {
+
+    /** Guards against pathologically deep fallback nesting. */
+    private static final int MAX_DEPTH = 50;
+
+    private CSSVariableSubstitution() {}
+
+    /**
+     * Resolves a custom property name (including the leading {@code --}) to its
+     * already fully-substituted value, or {@code null} if undefined or invalid
+     * (e.g. part of a reference cycle).
+     */
+    public interface VarResolver {
+        String resolve(String customPropertyName);
+    }
+
+    public static final class Result {
+        private final String text;
+        private final boolean resolved;
+
+        Result(String text, boolean resolved) {
+            this.text = text;
+            this.resolved = resolved;
+        }
+
+        /** The substituted value text (only meaningful when {@link #isResolved()}). */
+        public String getText() {
+            return text;
+        }
+
+        /** True if every {@code var()} reference was resolved (or had a fallback). */
+        public boolean isResolved() {
+            return resolved;
+        }
+    }
+
+    /**
+     * Returns true if the value text contains a {@code var(} token. Cheap
+     * pre-check to avoid running the full substitution on var-free values.
+     */
+    public static boolean containsVar(String valueText) {
+        return indexOfVar(valueText, 0) >= 0;
+    }
+
+    public static Result substitute(String valueText, VarResolver resolver) {
+        return substitute(valueText, resolver, 0);
+    }
+
+    private static Result substitute(String valueText, VarResolver resolver, int depth) {
+        if (depth > MAX_DEPTH) {
+            return new Result(valueText, false);
+        }
+
+        int from = indexOfVar(valueText, 0);
+        if (from < 0) {
+            return new Result(valueText, true);
+        }
+
+        StringBuilder out = new StringBuilder(valueText.length());
+        int pos = 0;
+        boolean resolved = true;
+
+        while (from >= 0) {
+            out.append(valueText, pos, from);
+
+            int open = from + 3; // index of '(' in "var("
+            int close = matchingParen(valueText, open);
+            if (close < 0) {
+                // Unterminated var(): bail out as invalid.
+                return new Result(valueText, false);
+            }
+
+            String inner = valueText.substring(open + 1, close);
+            int comma = topLevelComma(inner);
+
+            String name = (comma < 0 ? inner : inner.substring(0, comma)).trim();
+            String fallback = comma < 0 ? null : inner.substring(comma + 1);
+
+            String replacement = name.startsWith("--") ? resolver.resolve(name) : null;
+
+            if (replacement == null) {
+                if (fallback != null) {
+                    Result fb = substitute(fallback.trim(), resolver, depth + 1);
+                    if (!fb.isResolved()) {
+                        resolved = false;
+                    }
+                    out.append(fb.getText());
+                } else {
+                    // Undefined with no fallback: invalid at computed-value time.
+                    resolved = false;
+                }
+            } else {
+                out.append(replacement);
+            }
+
+            pos = close + 1;
+            from = indexOfVar(valueText, pos);
+        }
+
+        out.append(valueText, pos, valueText.length());
+        return new Result(out.toString(), resolved);
+    }
+
+    /**
+     * Finds the next {@code var(} that begins a function token (i.e. not part of
+     * a longer identifier such as {@code sidebar(}), starting at {@code start}.
+     * Returns the index of the {@code v}, or -1.
+     */
+    private static int indexOfVar(String s, int start) {
+        int i = start;
+        while (true) {
+            int idx = indexOfIgnoreCase(s, "var(", i);
+            if (idx < 0) {
+                return -1;
+            }
+            char prev = idx == 0 ? '\0' : s.charAt(idx - 1);
+            if (!isIdentChar(prev)) {
+                return idx;
+            }
+            i = idx + 1;
+        }
+    }
+
+    private static int indexOfIgnoreCase(String s, String needle, int from) {
+        int max = s.length() - needle.length();
+        for (int i = Math.max(from, 0); i <= max; i++) {
+            if (s.regionMatches(true, i, needle, 0, needle.length())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isIdentChar(char c) {
+        return c == '-' || c == '_' || Character.isLetterOrDigit(c);
+    }
+
+    /**
+     * Given the index of an opening paren, returns the index of its matching
+     * closing paren, accounting for nested parens and quoted strings, or -1.
+     */
+    private static int matchingParen(String s, int open) {
+        int depth = 0;
+        char quote = 0;
+        for (int i = open; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (quote != 0) {
+                if (c == '\\') {
+                    i++; // skip escaped char
+                } else if (c == quote) {
+                    quote = 0;
+                }
+            } else if (c == '"' || c == '\'') {
+                quote = c;
+            } else if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the index of the first top-level comma in {@code s} (depth 0, not
+     * inside parens or quotes), or -1 if there is none.
+     */
+    private static int topLevelComma(String s) {
+        int depth = 0;
+        char quote = 0;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (quote != 0) {
+                if (c == '\\') {
+                    i++;
+                } else if (c == quote) {
+                    quote = 0;
+                }
+            } else if (c == '"' || c == '\'') {
+                quote = c;
+            } else if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (c == ',' && depth == 0) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/CustomPropertyDeclaration.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/CustomPropertyDeclaration.java
@@ -1,0 +1,97 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2024 openhtmltopdf contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package com.openhtmltopdf.css.sheet;
+
+/**
+ * A CSS custom property declaration (a property whose name starts with
+ * {@code --}, e.g. {@code --main-color: red}). Custom properties are not
+ * keyed by a {@link com.openhtmltopdf.css.constants.CSSName} (the name is
+ * author-defined), so they are not regular {@link PropertyDeclaration}s and
+ * are kept in a parallel cascade.
+ *
+ * <p>The value is stored as raw text (which may itself contain {@code var()}
+ * references) and is resolved per element at computed-value time.</p>
+ */
+public class CustomPropertyDeclaration {
+
+    /** Bucketing of importance and origin, mirroring {@link PropertyDeclaration}. */
+    private final static int USER_AGENT = 1;
+    private final static int USER_NORMAL = 2;
+    private final static int AUTHOR_NORMAL = 3;
+    private final static int AUTHOR_IMPORTANT = 4;
+    private final static int USER_IMPORTANT = 5;
+
+    private final String name;
+    private final String valueText;
+    private final boolean important;
+    private final int origin;
+
+    private String _fingerprint;
+
+    public CustomPropertyDeclaration(String name, String valueText, boolean important, int origin) {
+        this.name = name;
+        this.valueText = valueText;
+        this.important = important;
+        this.origin = origin;
+    }
+
+    /** The custom property name, including the leading {@code --}. */
+    public String getName() {
+        return name;
+    }
+
+    /** The raw (unsubstituted) value text; may contain {@code var()} references. */
+    public String getValueText() {
+        return valueText;
+    }
+
+    public boolean isImportant() {
+        return important;
+    }
+
+    public int getOrigin() {
+        return origin;
+    }
+
+    /**
+     * @see PropertyDeclaration#getImportanceAndOrigin()
+     */
+    public int getImportanceAndOrigin() {
+        if (origin == StylesheetInfo.USER_AGENT) {
+            return USER_AGENT;
+        } else if (origin == StylesheetInfo.USER) {
+            return important ? USER_IMPORTANT : USER_NORMAL;
+        } else {
+            return important ? AUTHOR_IMPORTANT : AUTHOR_NORMAL;
+        }
+    }
+
+    public String getFingerprint() {
+        if (_fingerprint == null) {
+            _fingerprint = "C" + name + ':' + valueText + (important ? "!" : "") + ';';
+        }
+        return _fingerprint;
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + valueText + (important ? " !important" : "");
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/PendingVarPropertyDeclaration.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/PendingVarPropertyDeclaration.java
@@ -1,0 +1,73 @@
+/*
+ * {{{ header & license
+ * Copyright (c) 2024 openhtmltopdf contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * }}}
+ */
+package com.openhtmltopdf.css.sheet;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
+import com.openhtmltopdf.css.parser.PropertyValue;
+
+/**
+ * A property declaration whose value contains one or more {@code var()}
+ * references. This models the CSS "pending-substitution value": the value
+ * cannot be validated or built into a typed value at parse time because the
+ * custom properties it references are only known per element at
+ * computed-value time.
+ *
+ * <p>The declaration is keyed by its real {@link CSSName} so it participates
+ * normally in the cascade. Its raw value text is kept verbatim and is
+ * substituted then re-parsed when the computed style for an element is
+ * derived (see {@code com.openhtmltopdf.css.style.CalculatedStyle}).</p>
+ */
+public class PendingVarPropertyDeclaration extends PropertyDeclaration {
+
+    private final String valueText;
+    private String _fingerprint;
+
+    public PendingVarPropertyDeclaration(CSSName cssName, String valueText, boolean important, int origin) {
+        // The wrapped value is only a placeholder; the property is never derived
+        // directly. Resolution substitutes valueText and re-parses it.
+        super(cssName, new PropertyValue(CSSPrimitiveValue.CSS_STRING, valueText, valueText), important, origin);
+        this.valueText = valueText;
+    }
+
+    /** The raw value text, with {@code var()} references unsubstituted. */
+    public String getValueText() {
+        return valueText;
+    }
+
+    @Override
+    public String getFingerprint() {
+        if (_fingerprint == null) {
+            _fingerprint = "V" + getCSSName().FS_ID + ':' + valueText + (isImportant() ? "!" : "") + ';';
+        }
+        return _fingerprint;
+    }
+
+    @Override
+    public void toCSS(StringBuilder sb) {
+        sb.append(getPropertyName());
+        sb.append(": ");
+        sb.append(valueText);
+        if (isImportant()) {
+            sb.append(" !important");
+        }
+        sb.append(';');
+    }
+}

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/Ruleset.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/sheet/Ruleset.java
@@ -34,6 +34,7 @@ public class Ruleset {
     private final List<PropertyDeclaration> _props;
     private final List<Selector> _fsSelectors;
     private List<InvalidPropertyDeclaration> _invalidProperties;
+    private List<CustomPropertyDeclaration> _customProperties;
 
     public Ruleset(int orig) {
         _origin = orig;
@@ -104,5 +105,16 @@ public class Ruleset {
 
     public List<InvalidPropertyDeclaration> getInvalidPropertyDeclarations() {
         return _invalidProperties == null ? Collections.emptyList() : _invalidProperties;
+    }
+
+    public void addCustomProperty(CustomPropertyDeclaration customPropertyDeclaration) {
+        if (_customProperties == null) {
+            _customProperties = new ArrayList<>();
+        }
+        _customProperties.add(customPropertyDeclaration);
+    }
+
+    public List<CustomPropertyDeclaration> getCustomPropertyDeclarations() {
+        return _customProperties == null ? Collections.emptyList() : _customProperties;
     }
 }

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -22,6 +22,7 @@ package com.openhtmltopdf.css.style;
 
 import java.awt.Cursor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -645,15 +646,25 @@ public class CalculatedStyle {
         // inherited custom property.
         deriveCustomProperties(matched);
 
-        // Apply in ascending cascade priority so the highest-priority writer of
-        // each longhand wins. This only matters when a var()-bearing shorthand
-        // (kept under the shorthand CSSName, e.g. "padding") and an explicit
-        // longhand (e.g. "padding-left") both target the same longhand, which the
-        // per-CSSName cascade can't order. See CascadedStyle#getMatchSequence.
-        List<PropertyDeclaration> ordered = new ArrayList<>(matched.getCascadedPropertyDeclarations());
-        ordered.sort(Comparator.comparingInt(d -> matched.getMatchSequence(d.getCSSName())));
+        Collection<PropertyDeclaration> declarations = matched.getCascadedPropertyDeclarations();
 
-        for (PropertyDeclaration pd : ordered) {
+        if (matched.hasPendingVarProperties()) {
+            // Apply in ascending cascade priority so the highest-priority writer
+            // of each longhand wins. This only matters when a var()-bearing
+            // shorthand (kept under the shorthand CSSName, e.g. "padding") and an
+            // explicit longhand (e.g. "padding-left") both target the same
+            // longhand, which the per-CSSName cascade can't order. See
+            // CascadedStyle#getMatchSequence.
+            //
+            // Without a pending declaration every entry writes a distinct
+            // _derivedValuesById slot (the cascade is keyed by CSSName), so the
+            // order cannot matter and we skip the copy and the sort.
+            List<PropertyDeclaration> ordered = new ArrayList<>(declarations);
+            ordered.sort(Comparator.comparingInt(d -> matched.getMatchSequence(d.getCSSName())));
+            declarations = ordered;
+        }
+
+        for (PropertyDeclaration pd : declarations) {
             if (pd instanceof PendingVarPropertyDeclaration) {
                 resolvePendingVar((PendingVarPropertyDeclaration) pd);
             } else {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -702,6 +702,11 @@ public class CalculatedStyle {
     private void resolvePendingVar(PendingVarPropertyDeclaration pd) {
         String substituted = substitutePendingVar(pd);
         if (substituted == null) {
+            // Known limitation: when a var()-bearing shorthand wins the cascade but
+            // is invalid at computed-value time, we leave the longhands as-is instead
+            // of unsetting them. So a lower-priority explicit longhand applied earlier
+            // (e.g. "padding-left: 5px; padding: var(--undefined)") survives, whereas
+            // per spec the whole shorthand should compute to unset. Rare in practice.
             return;
         }
 

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/css/style/CalculatedStyle.java
@@ -23,8 +23,13 @@ package com.openhtmltopdf.css.style;
 import java.awt.Cursor;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -32,14 +37,19 @@ import com.openhtmltopdf.context.StyleReference;
 import com.openhtmltopdf.css.constants.CSSName;
 import com.openhtmltopdf.css.constants.IdentValue;
 import com.openhtmltopdf.css.newmatch.CascadedStyle;
+import com.openhtmltopdf.css.parser.CSSParser;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
+import com.openhtmltopdf.css.parser.CSSVariableSubstitution;
 import com.openhtmltopdf.css.parser.CounterData;
 import com.openhtmltopdf.css.parser.FSColor;
 import com.openhtmltopdf.css.parser.FSFunction;
 import com.openhtmltopdf.css.parser.FSRGBColor;
 import com.openhtmltopdf.css.parser.PropertyValue;
 import com.openhtmltopdf.css.parser.property.PrimitivePropertyBuilders;
+import com.openhtmltopdf.css.sheet.CustomPropertyDeclaration;
+import com.openhtmltopdf.css.sheet.PendingVarPropertyDeclaration;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
+import com.openhtmltopdf.css.sheet.Ruleset;
 import com.openhtmltopdf.css.style.derived.BorderPropertySet;
 import com.openhtmltopdf.css.style.derived.CountersValue;
 import com.openhtmltopdf.css.style.derived.DerivedValueFactory;
@@ -96,6 +106,14 @@ public class CalculatedStyle {
      * The parent-style we inherit from
      */
     private CalculatedStyle _parent;
+
+    /**
+     * This element's effective CSS custom properties ({@code --*}), keyed by
+     * name and holding raw (possibly {@code var()}-containing) value text. It is
+     * the parent's map overlaid with this element's own custom declarations, so
+     * custom properties inherit by default. Read-only after {@link #derive}.
+     */
+    private Map<String, String> _customProperties = Collections.emptyMap();
 
     private BorderPropertySet _border;
     private RectPropertySet _margin;
@@ -622,10 +640,154 @@ public class CalculatedStyle {
             return;
         }
 
-        for (PropertyDeclaration pd : matched.getCascadedPropertyDeclarations()) {
-            FSDerivedValue val = deriveValue(pd.getCSSName(), pd.getValue());
-            _derivedValuesById[pd.getCSSName().FS_ID] = val;
+        // Build this element's custom property environment before resolving any
+        // var() references, since a reference can resolve against an own or an
+        // inherited custom property.
+        deriveCustomProperties(matched);
+
+        // Apply in ascending cascade priority so the highest-priority writer of
+        // each longhand wins. This only matters when a var()-bearing shorthand
+        // (kept under the shorthand CSSName, e.g. "padding") and an explicit
+        // longhand (e.g. "padding-left") both target the same longhand, which the
+        // per-CSSName cascade can't order. See CascadedStyle#getMatchSequence.
+        List<PropertyDeclaration> ordered = new ArrayList<>(matched.getCascadedPropertyDeclarations());
+        ordered.sort(Comparator.comparingInt(d -> matched.getMatchSequence(d.getCSSName())));
+
+        for (PropertyDeclaration pd : ordered) {
+            if (pd instanceof PendingVarPropertyDeclaration) {
+                resolvePendingVar((PendingVarPropertyDeclaration) pd);
+            } else {
+                FSDerivedValue val = deriveValue(pd.getCSSName(), pd.getValue());
+                _derivedValuesById[pd.getCSSName().FS_ID] = val;
+            }
         }
+    }
+
+    /**
+     * Builds {@link #_customProperties}: the inherited map overlaid with this
+     * element's own {@code --*} declarations (handling initial/inherit/unset).
+     */
+    private void deriveCustomProperties(CascadedStyle matched) {
+        Map<String, CustomPropertyDeclaration> own = matched.getCustomProperties();
+        Map<String, String> inherited =
+                _parent != null ? _parent._customProperties : Collections.<String, String>emptyMap();
+
+        if (own.isEmpty()) {
+            // Share the parent's map; it is treated as read-only.
+            _customProperties = inherited;
+            return;
+        }
+
+        Map<String, String> map = new HashMap<>(inherited);
+        for (CustomPropertyDeclaration decl : own.values()) {
+            String raw = decl.getValueText().trim();
+            if (raw.equalsIgnoreCase("initial")) {
+                // Custom property initial value is the guaranteed-invalid value.
+                map.remove(decl.getName());
+            } else if (raw.equalsIgnoreCase("inherit") || raw.equalsIgnoreCase("unset")) {
+                // Custom properties inherit, so both keep the inherited value.
+            } else {
+                map.put(decl.getName(), decl.getValueText());
+            }
+        }
+        _customProperties = map;
+    }
+
+    /**
+     * Resolves a {@code var()}-bearing declaration: substitutes the references,
+     * then re-parses the result so shorthands and multi-value properties expand
+     * normally. On failure the property is left unset (inherits/initial), per CSS
+     * "invalid at computed-value time".
+     */
+    private void resolvePendingVar(PendingVarPropertyDeclaration pd) {
+        String substituted = substitutePendingVar(pd);
+        if (substituted == null) {
+            return;
+        }
+
+        String declarationText = pd.getPropertyName() + ": " + substituted;
+        try {
+            Ruleset ruleset = newVarCssParser().parseDeclaration(pd.getOrigin(), declarationText);
+            for (PropertyDeclaration newPd : ruleset.getPropertyDeclarations()) {
+                if (newPd instanceof PendingVarPropertyDeclaration) {
+                    // Should not occur once fully substituted; ignore defensively.
+                    continue;
+                }
+                FSDerivedValue val = deriveValue(newPd.getCSSName(), newPd.getValue());
+                _derivedValuesById[newPd.getCSSName().FS_ID] = val;
+            }
+        } catch (RuntimeException e) {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.CSS_PARSE_GENERIC_MESSAGE,
+                    "var() substitution",
+                    "Could not parse resolved declaration '" + declarationText +
+                            "'; treating it as unset.");
+        }
+    }
+
+    /**
+     * Like {@link #resolvePendingVar} but returns the resolved value as a single
+     * {@link PropertyValue} (or {@code null}). Used for values read directly
+     * rather than via {@link #valueByName(CSSName)}, such as {@code content}.
+     */
+    public PropertyValue resolvePendingVarPropertyValue(PendingVarPropertyDeclaration pd) {
+        String substituted = substitutePendingVar(pd);
+        if (substituted == null) {
+            return null;
+        }
+        try {
+            return newVarCssParser().parsePropertyValue(pd.getCSSName(), pd.getOrigin(), substituted);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Substitutes the {@code var()} references in a pending declaration against
+     * this element's environment, or returns {@code null} if any is unresolved.
+     */
+    private String substitutePendingVar(PendingVarPropertyDeclaration pd) {
+        Set<String> resolving = new HashSet<>();
+        CSSVariableSubstitution.Result result = CSSVariableSubstitution.substitute(
+                pd.getValueText(), name -> resolveCustomProperty(name, resolving));
+
+        if (!result.isResolved()) {
+            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.CSS_PARSE_GENERIC_MESSAGE,
+                    "var() substitution",
+                    "Unresolved var() in '" + pd.getPropertyName() + ": " + pd.getValueText() +
+                            "'; treating the declaration as unset.");
+            return null;
+        }
+        return result.getText();
+    }
+
+    /**
+     * Resolves a custom property name to its fully-substituted value text, or
+     * {@code null} if it is undefined or part of a reference cycle.
+     */
+    private String resolveCustomProperty(String name, Set<String> resolving) {
+        String raw = _customProperties.get(name);
+        if (raw == null || resolving.contains(name)) {
+            return null;
+        }
+        if (!CSSVariableSubstitution.containsVar(raw)) {
+            return raw;
+        }
+        resolving.add(name);
+        try {
+            CSSVariableSubstitution.Result r = CSSVariableSubstitution.substitute(
+                    raw, n -> resolveCustomProperty(n, resolving));
+            return r.isResolved() ? r.getText() : null;
+        } finally {
+            // Remove on exit so a name is blocked only while on the current
+            // resolution stack (a real cycle), not after it has resolved once:
+            // a value like "var(--a) var(--a)" must still resolve the second use.
+            resolving.remove(name);
+        }
+    }
+
+    private static CSSParser newVarCssParser() {
+        return new CSSParser((uri, message) ->
+                XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.CSS_PARSE_GENERIC_MESSAGE, uri, message));
     }
 
     private FSDerivedValue deriveValue(CSSName cssName, CSSPrimitiveValue value) {

--- a/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/BoxBuilder.java
+++ b/openhtmltopdf-core/src/main/java/com/openhtmltopdf/layout/BoxBuilder.java
@@ -48,6 +48,7 @@ import com.openhtmltopdf.css.newmatch.PageInfo;
 import com.openhtmltopdf.css.parser.CSSPrimitiveValue;
 import com.openhtmltopdf.css.parser.FSFunction;
 import com.openhtmltopdf.css.parser.PropertyValue;
+import com.openhtmltopdf.css.sheet.PendingVarPropertyDeclaration;
 import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.StylesheetInfo;
 import com.openhtmltopdf.css.style.CalculatedStyle;
@@ -326,6 +327,10 @@ public class BoxBuilder {
         result.setElement(c.getRootLayer().getMaster().getElement()); // XXX Doesn't make sense, but we need something here
 
         if (hasContent && ! style.isDisplayNone()) {
+            // TODO: unlike ::before/::after (see resolvePendingVarPropertyValue),
+            // var()/custom properties are not resolved here, so @page margin-box
+            // content can't use them (would also need getPageCascadedStyle to
+            // collect custom-property declarations).
             children.addAll(createGeneratedMarginBoxContent(
                     c,
                     c.getRootLayer().getMaster().getElement(),
@@ -1030,9 +1035,18 @@ public class BoxBuilder {
             }
 
             if (contentDecl != null) {
-                CSSPrimitiveValue propValue = contentDecl.getValue();
-                children.addAll(createGeneratedContent(c, element, peName, calculatedStyle,
-                        (PropertyValue) propValue, info));
+                CSSPrimitiveValue propValue;
+                if (contentDecl instanceof PendingVarPropertyDeclaration) {
+                    // The content value contains var(); resolve it per element.
+                    propValue = calculatedStyle.resolvePendingVarPropertyValue(
+                            (PendingVarPropertyDeclaration) contentDecl);
+                } else {
+                    propValue = contentDecl.getValue();
+                }
+                if (propValue != null) {
+                    children.addAll(createGeneratedContent(c, element, peName, calculatedStyle,
+                            (PropertyValue) propValue, info));
+                }
             }
         }
     }

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSParserTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSParserTest.java
@@ -1,6 +1,9 @@
 package com.openhtmltopdf.css.parser;
 
+import com.openhtmltopdf.css.sheet.CustomPropertyDeclaration;
 import com.openhtmltopdf.css.sheet.PageRule;
+import com.openhtmltopdf.css.sheet.PendingVarPropertyDeclaration;
+import com.openhtmltopdf.css.sheet.PropertyDeclaration;
 import com.openhtmltopdf.css.sheet.Ruleset;
 import com.openhtmltopdf.css.sheet.Stylesheet;
 import org.junit.Test;
@@ -9,9 +12,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -53,6 +58,16 @@ public class CSSParserTest {
         }
     }
 
+    private static Ruleset firstRuleset(String css) {
+        try {
+            Stylesheet stylesheet = parser.parseStylesheet("test://var", 0, new StringReader(css));
+            return (Ruleset) stylesheet.getContents().get(0);
+        } catch (IOException e) {
+            fail();
+            return null;
+        }
+    }
+
     @Test
     public void rgba_hsla_color() {
         Stylesheet stylesheet = parseStylesheet("rgba_hsla_color.css");
@@ -75,4 +90,52 @@ public class CSSParserTest {
         }
     }
 
+    @Test
+    public void customPropertyIsRetained() {
+        Ruleset ruleset = firstRuleset(":root { --main-color: red; }");
+
+        // Custom properties are not regular declarations...
+        assertTrue(ruleset.getPropertyDeclarations().isEmpty());
+
+        // ...they are kept in a parallel list.
+        List<CustomPropertyDeclaration> customProps = ruleset.getCustomPropertyDeclarations();
+        assertEquals(1, customProps.size());
+        assertEquals("--main-color", customProps.get(0).getName());
+        assertEquals("red", customProps.get(0).getValueText());
+    }
+
+    @Test
+    public void customPropertyMultiValueTextIsPreserved() {
+        Ruleset ruleset = firstRuleset(":root { --box: 1px solid red; }");
+        assertEquals("1px solid red", ruleset.getCustomPropertyDeclarations().get(0).getValueText());
+    }
+
+    @Test
+    public void varBearingDeclarationBecomesPending() {
+        Ruleset ruleset = firstRuleset("p { color: var(--main-color); }");
+
+        List<PropertyDeclaration> decls = ruleset.getPropertyDeclarations();
+        assertEquals(1, decls.size());
+        assertTrue(decls.get(0) instanceof PendingVarPropertyDeclaration);
+
+        PendingVarPropertyDeclaration pending = (PendingVarPropertyDeclaration) decls.get(0);
+        assertEquals("color", pending.getPropertyName());
+        assertEquals("var(--main-color)", pending.getValueText());
+    }
+
+    @Test
+    public void varFallbackTextIsPreserved() {
+        Ruleset ruleset = firstRuleset("p { border: var(--b, 1px solid red); }");
+        PendingVarPropertyDeclaration pending =
+                (PendingVarPropertyDeclaration) ruleset.getPropertyDeclarations().get(0);
+        // The fallback's internal spaces must survive (not become commas).
+        assertEquals("var(--b, 1px solid red)", pending.getValueText());
+    }
+
+    @Test
+    public void varFreeDeclarationIsBuiltNormally() {
+        Ruleset ruleset = firstRuleset("p { color: red; }");
+        assertEquals(1, ruleset.getPropertyDeclarations().size());
+        assertFalse(ruleset.getPropertyDeclarations().get(0) instanceof PendingVarPropertyDeclaration);
+    }
 }

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSVariableSubstitutionTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSVariableSubstitutionTest.java
@@ -1,0 +1,126 @@
+package com.openhtmltopdf.css.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.openhtmltopdf.css.parser.CSSVariableSubstitution.Result;
+import com.openhtmltopdf.css.parser.CSSVariableSubstitution.VarResolver;
+
+public class CSSVariableSubstitutionTest {
+
+    private static VarResolver resolver(String... pairs) {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            map.put(pairs[i], pairs[i + 1]);
+        }
+        return map::get;
+    }
+
+    private static String resolved(String input, VarResolver resolver) {
+        Result r = CSSVariableSubstitution.substitute(input, resolver);
+        assertTrue("expected '" + input + "' to be fully resolved", r.isResolved());
+        return r.getText();
+    }
+
+    @Test
+    public void simpleSubstitution() {
+        assertEquals("red", resolved("var(--a)", resolver("--a", "red")));
+    }
+
+    @Test
+    public void surroundingTextIsPreserved() {
+        assertEquals("1px solid red", resolved("1px solid var(--c)", resolver("--c", "red")));
+    }
+
+    @Test
+    public void multipleReferences() {
+        assertEquals("1px 2px", resolved("var(--a) var(--b)", resolver("--a", "1px", "--b", "2px")));
+    }
+
+    @Test
+    public void fallbackWhenUndefined() {
+        assertEquals("blue", resolved("var(--missing, blue)", resolver()));
+    }
+
+    @Test
+    public void fallbackPreservesSpaces() {
+        // Must NOT collapse to "1px,solid,red".
+        assertEquals("1px solid red", resolved("var(--m, 1px solid red)", resolver()));
+    }
+
+    @Test
+    public void fallbackCanContainVar() {
+        assertEquals("green", resolved("var(--missing, var(--b))", resolver("--b", "green")));
+    }
+
+    @Test
+    public void nestedInsideFunction() {
+        assertEquals("calc(10px * 2)", resolved("calc(var(--a) * 2)", resolver("--a", "10px")));
+    }
+
+    @Test
+    public void commaInsideFallbackFunctionIsNotASeparator() {
+        assertEquals("rgb(1, 2, 3)", resolved("var(--x, rgb(1, 2, 3))", resolver()));
+    }
+
+    @Test
+    public void parenInsideStringIsRespected() {
+        assertEquals("\"a)b\"", resolved("var(--x, \"a)b\")", resolver()));
+    }
+
+    @Test
+    public void caseInsensitiveAndWhitespace() {
+        assertEquals("red", resolved("VAR( --a )", resolver("--a", "red")));
+    }
+
+    @Test
+    public void undefinedWithoutFallbackIsUnresolved() {
+        Result r = CSSVariableSubstitution.substitute("var(--missing)", resolver());
+        assertFalse(r.isResolved());
+    }
+
+    @Test
+    public void notAVarFunction() {
+        // "sidebar(" ends in "bar(" but the "var(" is part of an identifier.
+        assertFalse(CSSVariableSubstitution.containsVar("sidebar(--a)"));
+        Result r = CSSVariableSubstitution.substitute("sidebar(--a)", resolver("--a", "x"));
+        assertTrue(r.isResolved());
+        assertEquals("sidebar(--a)", r.getText());
+    }
+
+    @Test
+    public void containsVarDetection() {
+        assertTrue(CSSVariableSubstitution.containsVar("1px var(--a)"));
+        assertFalse(CSSVariableSubstitution.containsVar("1px solid red"));
+    }
+
+    @Test
+    public void emptyFallbackResolvesToEmpty() {
+        // var(--undefined,) is valid and resolves to an empty value.
+        assertEquals("", resolved("var(--missing,)", resolver()));
+    }
+
+    @Test
+    public void bareVarIsUnresolved() {
+        Result r = CSSVariableSubstitution.substitute("var()", resolver());
+        assertFalse(r.isResolved());
+    }
+
+    @Test
+    public void emptyNameFallsBackToFallback() {
+        // No valid custom-property name, but a fallback is present.
+        assertEquals("blue", resolved("var(, blue)", resolver()));
+    }
+
+    @Test
+    public void unterminatedVarIsUnresolved() {
+        Result r = CSSVariableSubstitution.substitute("var(--a", resolver("--a", "x"));
+        assertFalse(r.isResolved());
+    }
+}

--- a/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSVariableSubstitutionTest.java
+++ b/openhtmltopdf-core/src/test/java/com/openhtmltopdf/css/parser/CSSVariableSubstitutionTest.java
@@ -123,4 +123,24 @@ public class CSSVariableSubstitutionTest {
         Result r = CSSVariableSubstitution.substitute("var(--a", resolver("--a", "x"));
         assertFalse(r.isResolved());
     }
+
+    @Test
+    public void varInsideStringIsLiteralNotAReference() {
+        // A string token is opaque: "var(" inside it is literal text. Only the
+        // real var(--b) is substituted; the string is left untouched.
+        assertEquals("\"func(var(--a))\" YYY",
+                resolved("\"func(var(--a))\" var(--b)", resolver("--a", "XXX", "--b", "YYY")));
+    }
+
+    @Test
+    public void containsVarIgnoresVarInsideString() {
+        // The whole value is a single string that happens to contain "var(".
+        assertFalse(CSSVariableSubstitution.containsVar("\"hello var(--y)\""));
+    }
+
+    @Test
+    public void varRightAfterAClosedStringIsAReference() {
+        // The string closes at the quote, so the adjacent var( is a real function.
+        assertEquals("\"abc\"Z", resolved("\"abc\"var(--x)", resolver("--x", "Z")));
+    }
 }

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/CSSCustomPropertiesVarTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/CSSCustomPropertiesVarTest.java
@@ -371,4 +371,42 @@ public class CSSCustomPropertiesVarTest {
             "</style></head><body><div id=\"x\">X</div></body></html>");
         assertColor("x", 11, 22, 33);
     }
+
+    @Test
+    public void varAsRgbComponent() throws IOException {
+        // rgb()/rgba()/hsl()/cmyk() are evaluated while parsing, so a var()
+        // parameter has to defer the whole function to the pending path.
+        layoutHtml("<html><head><style>" +
+            "#x { --r: 10; color: rgb(var(--r), 20, 30); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 10, 20, 30);
+    }
+
+    @Test
+    public void varAsWholeRgbaArgumentList() throws IOException {
+        // One custom property standing in for several arguments at once.
+        layoutHtml("<html><head><style>" +
+            "#x { --rgb: 10, 20, 30; color: rgba(var(--rgb), 0.5); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 10, 20, 30);
+    }
+
+    @Test
+    public void varAsHslComponent() throws IOException {
+        layoutHtml("<html><head><style>" +
+            "#x { --h: 210; color: hsl(var(--h), 50%, 50%); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 64, 128, 191);
+    }
+
+    @Test
+    public void undefinedVarInRgbIsUnset() throws IOException {
+        // The deferred function must still go unset (here: inherit) when the
+        // reference cannot be resolved, not render as an unevaluated function.
+        layoutHtml("<html><head><style>" +
+            "body { color: rgb(7, 7, 7); }" +
+            "#x { color: rgb(var(--nope), 20, 30); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 7, 7, 7);
+    }
 }

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/CSSCustomPropertiesVarTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/CSSCustomPropertiesVarTest.java
@@ -1,0 +1,374 @@
+package com.openhtmltopdf.nonvisualregressiontests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.css.parser.FSRGBColor;
+import com.openhtmltopdf.pdfboxout.PdfBoxRenderer;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.render.BlockBox;
+import com.openhtmltopdf.render.Box;
+import com.openhtmltopdf.visualtest.TestSupport;
+
+/**
+ * End-to-end tests for CSS custom properties ({@code --*}) and {@code var()},
+ * exercising the real cascade and per-element computed-value resolution.
+ */
+public class CSSCustomPropertiesVarTest {
+
+    @BeforeClass
+    public static void configure() {
+        TestSupport.quietLogs();
+    }
+
+    private static final String HTML =
+        "<html><head><style>\n" +
+        ":root { --main: rgb(10, 20, 30); --gap: 7px; }\n" +
+        "#a { color: var(--main); }\n" +                          // :root variable
+        "#b { --main: rgb(40, 50, 60); color: var(--main); }\n" + // own override
+        "#b-child { color: var(--main); }\n" +                    // inherits #b's --main
+        "#c { color: var(--missing, rgb(70, 80, 90)); }\n" +      // fallback
+        "#d { padding: var(--gap); }\n" +                         // shorthand
+        "#e { color: var(--undefined); }\n" +                     // unresolved -> unset -> inherit
+        "#f { --x: var(--y); --y: var(--x); color: var(--x); }\n" + // reference cycle
+        "</style></head>\n" +
+        "<body style=\"color: rgb(1, 2, 3)\">\n" +
+        "  <div id=\"a\">A</div>\n" +
+        "  <div id=\"b\">B<div id=\"b-child\">child</div></div>\n" +
+        "  <div id=\"c\">C</div>\n" +
+        "  <div id=\"d\">D</div>\n" +
+        "  <div id=\"e\">E</div>\n" +
+        "  <div id=\"f\">F</div>\n" +
+        "</body></html>";
+
+    private BlockBox rootBox;
+
+    private void layout() throws IOException {
+        layoutHtml(HTML);
+    }
+
+    private void layoutHtml(String html) throws IOException {
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(new ByteArrayOutputStream());
+        try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
+            renderer.layout();
+            rootBox = renderer.getRootBox();
+        }
+    }
+
+    private String renderToText(String html) throws IOException {
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        builder.toStream(os);
+        builder.run();
+        try (PDDocument doc = Loader.loadPDF(os.toByteArray())) {
+            return new PDFTextStripper().getText(doc);
+        }
+    }
+
+    private Box byId(String id) {
+        Box found = findById(rootBox, id);
+        assertNotNull("no box for #" + id, found);
+        return found;
+    }
+
+    private static Box findById(Box box, String id) {
+        Element e = box.getElement();
+        if (e != null && id.equals(e.getAttribute("id"))) {
+            return box;
+        }
+        for (int i = 0; i < box.getChildCount(); i++) {
+            Box found = findById(box.getChild(i), id);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private void assertColor(String id, int r, int g, int b) {
+        assertColorOf(id, CSSName.COLOR, r, g, b);
+    }
+
+    private void assertColorOf(String id, CSSName name, int r, int g, int b) {
+        FSRGBColor rgb = (FSRGBColor) byId(id).getStyle().asColor(name);
+        assertEquals("#" + id + " " + name + " red", r, rgb.getRed());
+        assertEquals("#" + id + " " + name + " green", g, rgb.getGreen());
+        assertEquals("#" + id + " " + name + " blue", b, rgb.getBlue());
+    }
+
+    @Test
+    public void rootVariable() throws IOException {
+        layout();
+        assertColor("a", 10, 20, 30);
+    }
+
+    @Test
+    public void perElementOverride() throws IOException {
+        layout();
+        assertColor("b", 40, 50, 60);
+    }
+
+    @Test
+    public void inheritedCustomPropertyScoping() throws IOException {
+        layout();
+        // #b-child inherits --main from #b (40,50,60), not :root's (10,20,30).
+        assertColor("b-child", 40, 50, 60);
+    }
+
+    @Test
+    public void fallbackWhenUndefined() throws IOException {
+        layout();
+        assertColor("c", 70, 80, 90);
+    }
+
+    @Test
+    public void shorthandWithVar() throws IOException {
+        layout();
+        assertEquals(7f, byId("d").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+        assertEquals(7f, byId("d").getStyle().asFloat(CSSName.PADDING_TOP), 0.01f);
+    }
+
+    @Test
+    public void unresolvedVarFallsBackToInherited() throws IOException {
+        layout();
+        // var(--undefined) with no fallback -> unset -> inherits body color (1,2,3).
+        assertColor("e", 1, 2, 3);
+    }
+
+    @Test
+    public void cyclicReferenceIsTreatedAsUnset() throws IOException {
+        layout();
+        // --x and --y form a cycle, so var(--x) is invalid -> unset -> inherit (1,2,3).
+        assertColor("f", 1, 2, 3);
+    }
+
+    @Test
+    public void explicitLonghandOverridesVarShorthand() throws IOException {
+        // A var()-bearing shorthand must compete in the cascade at the longhand
+        // level, exactly like a normal shorthand. Here the later, same-specificity
+        // explicit padding-left/right: 0 must win over the earlier padding shorthand,
+        // while padding-top/bottom keep the shorthand's 16px. This mirrors Orbeon's
+        // ".fr-section-content { padding: var(--x) }" plus
+        // "@media print { ...; padding-left: 0; padding-right: 0 }".
+        String html =
+            "<html><head><style>" +
+            ":root { --pad: 16px; }" +
+            "#x { padding: var(--pad); }" +
+            "#x { padding-left: 0; padding-right: 0; }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>";
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(new ByteArrayOutputStream());
+        try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
+            renderer.layout();
+            rootBox = renderer.getRootBox();
+        }
+
+        assertEquals("padding-left (explicit, later) must override the var shorthand",
+                0f, byId("x").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+        assertEquals("padding-right (explicit, later) must override the var shorthand",
+                0f, byId("x").getStyle().asFloat(CSSName.PADDING_RIGHT), 0.01f);
+        assertEquals("padding-top must keep the var shorthand value",
+                16f, byId("x").getStyle().asFloat(CSSName.PADDING_TOP), 0.01f);
+        assertEquals("padding-bottom must keep the var shorthand value",
+                16f, byId("x").getStyle().asFloat(CSSName.PADDING_BOTTOM), 0.01f);
+    }
+
+    @Test
+    public void varShorthandOverridesEarlierExplicitLonghand() throws IOException {
+        // The reverse order: a var()-bearing shorthand declared after an explicit
+        // longhand (same specificity) must win for every side it sets.
+        String html =
+            "<html><head><style>" +
+            ":root { --pad: 16px; }" +
+            "#x { padding-left: 0; }" +
+            "#x { padding: var(--pad); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>";
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(new ByteArrayOutputStream());
+        try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
+            renderer.layout();
+            rootBox = renderer.getRootBox();
+        }
+
+        assertEquals("later var shorthand must override the earlier explicit longhand",
+                16f, byId("x").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+    }
+
+    @Test
+    public void varInContentProperty() throws IOException {
+        String html =
+            "<html><head><style>" +
+            ":root { --label: \"GENERATED\"; }" +
+            "#x::before { content: var(--label); }" +
+            "</style></head><body><div id=\"x\"></div></body></html>";
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        builder.toStream(os);
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(os.toByteArray())) {
+            String text = new PDFTextStripper().getText(doc);
+            assertTrue("expected generated content from var(), got: " + text,
+                    text.contains("GENERATED"));
+        }
+    }
+
+    @Test
+    public void selfReferentialCycleIsUnset() throws IOException {
+        // --x references itself: invalid at computed-value time -> unset -> inherit.
+        layoutHtml("<html><head><style>" +
+            "#x { --x: var(--x); color: var(--x); }" +
+            "</style></head><body style=\"color: rgb(1, 2, 3)\"><div id=\"x\">X</div></body></html>");
+        assertColor("x", 1, 2, 3);
+    }
+
+    @Test
+    public void undefinedVarOnNonInheritedPropertyIsInitial() throws IOException {
+        // padding is not inherited, so an unresolved var() with no fallback -> unset
+        // -> the initial value (0), not the parent's 40px.
+        layoutHtml("<html><head><style>" +
+            "#p { padding-left: 40px; }" +
+            "#c { padding-left: var(--missing); }" +
+            "</style></head><body><div id=\"p\"><div id=\"c\">C</div></div></body></html>");
+        assertEquals(0f, byId("c").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+    }
+
+    @Test
+    public void varResolvingToPropertyInvalidValueIsUnset() throws IOException {
+        // --bad resolves fine as text, but "12px" is invalid for color, so the
+        // re-parse fails -> unset -> inherit the body color.
+        layoutHtml("<html><head><style>" +
+            "#x { --bad: 12px; color: var(--bad); }" +
+            "</style></head><body style=\"color: rgb(1, 2, 3)\"><div id=\"x\">X</div></body></html>");
+        assertColor("x", 1, 2, 3);
+    }
+
+    @Test
+    public void customPropertyNameIsCaseSensitive() throws IOException {
+        // --Foo and --foo are distinct names; var(--Foo) must pick --Foo.
+        layoutHtml("<html><head><style>" +
+            "#x { --Foo: rgb(11, 22, 33); --foo: rgb(99, 88, 77); color: var(--Foo); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 11, 22, 33);
+    }
+
+    @Test
+    public void importantOnVarDeclarationWins() throws IOException {
+        // The !important var declaration beats the later non-important one.
+        layoutHtml("<html><head><style>" +
+            ":root { --a: rgb(7, 7, 7); }" +
+            "#x { color: var(--a) !important; }" +
+            "#x { color: rgb(5, 5, 5); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 7, 7, 7);
+    }
+
+    @Test
+    public void borderShorthandWithVar() throws IOException {
+        // A var() border shorthand expands to the border-* longhands.
+        layoutHtml("<html><head><style>" +
+            "#x { --b: 2px solid rgb(10, 20, 30); border: var(--b); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertEquals(2f, byId("x").getStyle().asFloat(CSSName.BORDER_TOP_WIDTH), 0.01f);
+        assertColorOf("x", CSSName.BORDER_TOP_COLOR, 10, 20, 30);
+    }
+
+    @Test
+    public void varCombinedWithStaticToken() throws IOException {
+        // var() and a literal token in the same value: margin: 5px 10px.
+        layoutHtml("<html><head><style>" +
+            "#x { --c: 5px; margin: var(--c) 10px; }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertEquals(5f, byId("x").getStyle().asFloat(CSSName.MARGIN_TOP), 0.01f);
+        assertEquals(10f, byId("x").getStyle().asFloat(CSSName.MARGIN_LEFT), 0.01f);
+    }
+
+    @Test
+    public void customPropertyCascadeBySpecificity() throws IOException {
+        // The higher-specificity #x rule's --x wins over the div rule's.
+        layoutHtml("<html><head><style>" +
+            "div { --x: rgb(1, 1, 1); }" +
+            "#x { --x: rgb(2, 2, 2); }" +
+            "#x { color: var(--x); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 2, 2, 2);
+    }
+
+    @Test
+    public void multiLevelVarChain() throws IOException {
+        // --a -> --b -> --c -> 9px (more than one level of indirection).
+        layoutHtml("<html><head><style>" +
+            "#x { --a: var(--b); --b: var(--c); --c: 9px; padding-left: var(--a); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertEquals(9f, byId("x").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+    }
+
+    @Test
+    public void identicalChildStylesResolveAgainstTheirOwnParent() throws IOException {
+        // l1 and l2 match the same rule (same fingerprint) but inherit different
+        // --x from their parents. The per-parent style cache must not collide.
+        layoutHtml("<html><head><style>" +
+            "#p1 { --x: rgb(1, 2, 3); } #p2 { --x: rgb(4, 5, 6); }" +
+            ".leaf { color: var(--x); }" +
+            "</style></head><body>" +
+            "<div id=\"p1\"><div class=\"leaf\" id=\"l1\">1</div></div>" +
+            "<div id=\"p2\"><div class=\"leaf\" id=\"l2\">2</div></div>" +
+            "</body></html>");
+        assertColor("l1", 1, 2, 3);
+        assertColor("l2", 4, 5, 6);
+    }
+
+    @Test
+    public void pseudoElementLocalCustomProperty() throws IOException {
+        // A custom property declared on the pseudo-element rule itself must be
+        // available to var() in that rule (regression test for getPECascadedStyle).
+        String text = renderToText("<html><head><style>" +
+            "#x::before { --c: \"LOCALVAR\"; content: var(--c); }" +
+            "</style></head><body><div id=\"x\"></div></body></html>");
+        assertTrue("expected pseudo-element-local var content, got: " + text,
+                text.contains("LOCALVAR"));
+    }
+
+    @Test
+    public void sameVarUsedTwiceIsNotACycle() throws IOException {
+        // The cycle guard tracks the current resolution stack, not "already seen":
+        // --g (which itself uses var) is resolved once per occurrence, so
+        // "var(--g) var(--g)" yields 4px on both sides rather than going unset.
+        layoutHtml("<html><head><style>" +
+            "#x { --base: 4px; --g: var(--base); padding: var(--g) var(--g); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertEquals(4f, byId("x").getStyle().asFloat(CSSName.PADDING_LEFT), 0.01f);
+        assertEquals(4f, byId("x").getStyle().asFloat(CSSName.PADDING_TOP), 0.01f);
+    }
+
+    @Test
+    public void nestedFallbackChain() throws IOException {
+        // Both --m and --n are undefined, so the value falls through to the
+        // innermost fallback.
+        layoutHtml("<html><head><style>" +
+            "#x { color: var(--m, var(--n, rgb(11, 22, 33))); }" +
+            "</style></head><body><div id=\"x\">X</div></body></html>");
+        assertColor("x", 11, 22, 33);
+    }
+}

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/VarMarginShorthandTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/VarMarginShorthandTest.java
@@ -1,0 +1,104 @@
+package com.openhtmltopdf.nonvisualregressiontests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import com.openhtmltopdf.css.constants.CSSName;
+import com.openhtmltopdf.pdfboxout.PdfBoxRenderer;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.render.BlockBox;
+import com.openhtmltopdf.render.Box;
+import com.openhtmltopdf.visualtest.TestSupport;
+
+/**
+ * Checks that a margin shorthand resolved through var() expands to the same
+ * longhand values as the equivalent literal shorthand. Mirrors the Orbeon
+ * `.xforms-label { margin: var(--orbeon-grid-label-margin) }` case.
+ */
+public class VarMarginShorthandTest {
+
+    @BeforeClass
+    public static void configure() {
+        TestSupport.quietLogs();
+    }
+
+    private static final String HTML =
+        "<html><head><style>\n" +
+        ":root { --m: 2px 0 4px 0; --neg: -10px 0; }\n" +
+        "#lit { margin: 2px 0 4px 0; }\n" +
+        "#via { margin: var(--m); }\n" +
+        "#litNeg { margin: -10px 0; }\n" +
+        "#viaNeg { margin: var(--neg); }\n" +
+        "</style></head>\n" +
+        "<body>\n" +
+        "  <div id=\"lit\">lit</div>\n" +
+        "  <div id=\"via\">via</div>\n" +
+        "  <div id=\"litNeg\">litNeg</div>\n" +
+        "  <div id=\"viaNeg\">viaNeg</div>\n" +
+        "</body></html>";
+
+    private BlockBox rootBox;
+
+    private void layout() throws IOException {
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(HTML, null);
+        builder.toStream(new ByteArrayOutputStream());
+        try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
+            renderer.layout();
+            rootBox = renderer.getRootBox();
+        }
+    }
+
+    private Box byId(String id) {
+        Box found = findById(rootBox, id);
+        assertNotNull("no box for #" + id, found);
+        return found;
+    }
+
+    private static Box findById(Box box, String id) {
+        Element e = box.getElement();
+        if (e != null && id.equals(e.getAttribute("id"))) {
+            return box;
+        }
+        for (int i = 0; i < box.getChildCount(); i++) {
+            Box found = findById(box.getChild(i), id);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private void assertSameMargins(String litId, String viaId) {
+        Box lit = byId(litId);
+        Box via = byId(viaId);
+        for (CSSName side : new CSSName[] {
+                CSSName.MARGIN_TOP, CSSName.MARGIN_RIGHT, CSSName.MARGIN_BOTTOM, CSSName.MARGIN_LEFT }) {
+            assertEquals(side + " (" + litId + " vs " + viaId + ")",
+                    lit.getStyle().asFloat(side), via.getStyle().asFloat(side), 0.001f);
+        }
+    }
+
+    @Test
+    public void fourValueShorthand() throws IOException {
+        layout();
+        // Expect top=2, right=0, bottom=4, left=0
+        assertEquals(2f, byId("lit").getStyle().asFloat(CSSName.MARGIN_TOP), 0.001f);
+        assertEquals(4f, byId("lit").getStyle().asFloat(CSSName.MARGIN_BOTTOM), 0.001f);
+        assertSameMargins("lit", "via");
+    }
+
+    @Test
+    public void negativeShorthand() throws IOException {
+        layout();
+        assertEquals(-10f, byId("litNeg").getStyle().asFloat(CSSName.MARGIN_TOP), 0.001f);
+        assertSameMargins("litNeg", "viaNeg");
+    }
+}


### PR DESCRIPTION
Closes #114.

CSS Custom Properties (`--*` / `var()`). The implementation is @obruchez's, from Orbeon's fork ([offered here](https://github.com/openhtmltopdf/openhtmltopdf/issues/114#issuecomment-4960046435)); their three commits are cherry-picked unchanged, with authorship preserved. Thanks!

`var()` is resolved at computed-value time. Custom property declarations go into a parallel cascade; a declaration containing `var()` becomes a pending-substitution value that is substituted and re-parsed per element, so shorthands and multi-value properties expand through the normal builders. Custom properties inherit and are scoped per element, and they feed `CascadedStyle`'s fingerprint so the style cache can't hand two elements a style resolved against a different variable. `:root` is now supported as a side effect.

Three commits on top from me:

- `rgb()/rgba()/hsl()/hsla()/cmyk()` are evaluated while parsing, so `rgba(var(--brand), .5)` threw and the declaration was silently dropped. They now defer to the pending path when a parameter references a custom property.
- Only derive in cascade order when a pending declaration is actually present — without one every entry writes a distinct slot, so documents that use no variables skip the copy and the sort.
- Tests for the above.

Known limitations, unchanged from the issue: `var()` is not resolved in `@page` and its margin boxes (regular elements including `::before`/`::after` work); a `var()` shorthand that is invalid at computed-value time leaves already-applied longhands in place instead of unsetting them; and a custom property value has to parse as a CSS value expression rather than an arbitrary token stream. Also, `--foo` is rejoined from `MINUS` + `IDENT` in the parser because the bundled JFlex lexer does not emit a single dashed-ident token — a regenerated tokenizer would remove that.

54 new tests. Full suite green, `-Dmaven.compiler.release=8` compiles.

*AI generated text.*
