### PR TITLE
Fixes #100 - Don't tag <br> as a Span structure element in PDF/UA output

### DIFF
--- a/openhtmltopdf-examples/src/main/resources/testcases/pdfua/dd-with-br.html
+++ b/openhtmltopdf-examples/src/main/resources/testcases/pdfua/dd-with-br.html
@@ -1,0 +1,25 @@
+<html lang="en-US">
+<head>
+  <title>DD test</title>
+  <meta name="description" content="A dl/dd list where a dd contains a forced line break"/>
+  <meta name="subject" content="PDF/UA br in dd testcase, see issue 100"/>
+
+  <style>
+  @page {
+    size: 200px 200px;
+    margin: 0;
+  }
+  body {
+    margin: 0;
+    width: 200px;
+  }
+  </style>
+</head>
+<body style="font-family: 'TestFont'; font-size: 14px;">
+<dl>
+  <dt>Foo</dt>
+  <dd>Bar<br/>Baz
+  </dd>
+</dl>
+</body>
+</html>

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/NonVisualRegressionTest.java
@@ -44,6 +44,7 @@ import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlin
 import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
 import org.apache.pdfbox.pdmodel.interactive.form.PDRadioButton;
 import org.apache.pdfbox.pdmodel.interactive.form.PDTextField;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDMarkedContentReference;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDObjectReference;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
 import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureNode;
@@ -1245,13 +1246,231 @@ public class NonVisualRegressionTest {
     }
 
     private static void collectLinkStructureElements(PDStructureNode node, List<PDStructureElement> result) {
+        collectStructureElementsByType(node, "Link", result);
+    }
+
+    private static void collectStructureElementsByType(PDStructureNode node, String type, List<PDStructureElement> result) {
         for (Object kid : node.getKids()) {
             if (kid instanceof PDStructureElement) {
                 PDStructureElement elem = (PDStructureElement) kid;
-                if ("Link".equals(elem.getStructureType())) {
+                if (type.equals(elem.getStructureType())) {
                     result.add(elem);
                 }
-                collectLinkStructureElements(elem, result);
+                collectStructureElementsByType(elem, type, result);
+            }
+        }
+    }
+
+    /**
+     * Counts the real (MCID) leaf descendants of a structure node, recursing
+     * into nested structure elements. Used to detect empty structure elements
+     * that carry no actual marked content - e.g. a Span created only for
+     * a &lt;br&gt;'s invisible generated line-break content.
+     *
+     * Counts both plain Integer kids (same-page content) and
+     * PDMarkedContentReference kids (GenericContentItem#finish() emits the
+     * latter whenever the content is on a different page than its parent
+     * structure element, e.g. content split across a page break).
+     */
+    private static int countMcidLeafDescendants(PDStructureNode node) {
+        int count = 0;
+        for (Object kid : node.getKids()) {
+            if (kid instanceof PDStructureElement) {
+                count += countMcidLeafDescendants((PDStructureElement) kid);
+            } else if (kid instanceof Integer || kid instanceof PDMarkedContentReference) {
+                count++;
+            }
+            // Other kid types (PDObjectReference etc.) are not produced for
+            // plain text runs and are not relevant here.
+        }
+        return count;
+    }
+
+    /**
+     * Regression test for https://github.com/openhtmltopdf/openhtmltopdf/issues/100
+     *
+     * A &lt;br&gt; inside a &lt;dd&gt; (or any inline context) must not cause a Span
+     * structure element to be created for the br itself, nor for the anonymous
+     * inline box generated for its :before content (which implements the forced
+     * line break) - it should be exactly as invisible to the tag tree as an
+     * ordinary line break from natural word-wrapping is. Before the fix, the
+     * br (and its generated content) produced empty/spurious Span structure
+     * elements, which PDF/UA checkers such as PAC flag as "possibly
+     * inappropriate use of a Span structure element".
+     *
+     * Separately, real text content must still end up nested inside a
+     * content-permitting structure element rather than directly inside a
+     * "Grouping" element such as Div - per the PDF/UA nesting rules, Div must
+     * not directly contain marked content (PAC: "Marked content is present in
+     * a possibly inadmissible location"). dt/dd now map to P (a content-
+     * permitting block-level element) instead of falling through to Div, so
+     * "Foo", "Bar" and "Baz" attach directly to their own P with no Span
+     * wrapping needed at all - satisfying both PAC checks simultaneously,
+     * rather than trading one for the other.
+     *
+     * Note this is specific to dt/dd, not a general fix: other elements that
+     * fall through to Div (a plain multi-line <div>, for example) can still
+     * end up with marked content directly inside that Div. An earlier version
+     * of this fix addressed that generally, but doing so by tagging each
+     * wrapped *line* as its own P produced multiple sibling Ps mid-sentence -
+     * technically legal nesting, but confusing to screen readers/Reflow and
+     * not something any checker catches. A correct general fix needs one P
+     * for the whole contiguous run of line boxes (grouping how
+     * finishTreeItems() assigns a parent's children), not a per-box tag
+     * override, so it's being left for a follow-up rather than folded in here.
+     *
+     * This is deliberately not a pixel-based visual regression test: the fix only
+     * changes the invisible /Tags structure tree, not the rendered page content, so
+     * a pixel diff would pass identically before and after the fix and would not
+     * catch a regression. Asserting on the structure tree is the meaningful
+     * regression test for this class of bug.
+     */
+    @Test
+    public void testBrInDdDoesNotProduceEmptySpans() throws IOException {
+        String html =
+            "<html lang='en-US'><head>" +
+            "<title>DD test</title>" +
+            "<meta name='description' content='Regression test for issue 100'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<dl><dt>Foo</dt><dd>Bar<br/>Baz\n</dd></dl>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+            assertNotNull("Structure tree root should exist", root);
+
+            List<PDStructureElement> spans = new ArrayList<>();
+            collectStructureElementsByType(root, "Span", spans);
+
+            // No Span may be empty (i.e. carry no real text content). Before the fix,
+            // the <br> itself and its generated :before content each produced such an
+            // empty/spurious Span.
+            for (PDStructureElement span : spans) {
+                assertTrue(
+                    "Found a Span structure element with no real (MCID) content - " +
+                    "this is exactly the kind of node PDF/UA checkers flag as " +
+                    "\"possibly inappropriate use of a Span structure element\"",
+                    countMcidLeafDescendants(span) > 0);
+            }
+
+            // With dt/dd mapping to P, no Span wrapping is needed at all: a <br>
+            // should be exactly as invisible to the tag tree as natural
+            // word-wrapping already is.
+            assertEquals("Should find no Span structure elements at all", 0, spans.size());
+
+            // Each of "Foo", "Bar" and "Baz" should have landed inside its own P.
+            List<PDStructureElement> paragraphs = new ArrayList<>();
+            collectStructureElementsByType(root, "P", paragraphs);
+            assertEquals("Should find exactly 2 P structure elements (dt and dd)", 2, paragraphs.size());
+            for (PDStructureElement p : paragraphs) {
+                assertTrue("Each P should contain real (MCID) content",
+                    countMcidLeafDescendants(p) > 0);
+            }
+
+            // No Div (or other "Grouping" element) may directly contain marked
+            // content (a leaf MCID reference) in *this* testcase specifically -
+            // guaranteed here by dt/dd mapping to P rather than falling through
+            // to Div. (Other elements that still fall through to Div can still
+            // end up with content directly inside it - see the class javadoc
+            // above for why that's left as a follow-up rather than fixed here.)
+            for (String groupingType : new String[] { "Div", "Sect", "Art", "Part", "BlockQuote" }) {
+                List<PDStructureElement> groupingElements = new ArrayList<>();
+                collectStructureElementsByType(root, groupingType, groupingElements);
+                for (PDStructureElement el : groupingElements) {
+                    for (Object kid : el.getKids()) {
+                        assertFalse(
+                            "A " + groupingType + " must not directly contain marked content " +
+                            "(an Integer or PDMarkedContentReference kid) - PDF/UA checkers flag " +
+                            "this as \"Marked content is present in a possibly inadmissible " +
+                            "location\". Wrap it in a P (or other content-permitting element) instead.",
+                            kid instanceof Integer || kid instanceof PDMarkedContentReference);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Companion to testBrInDdDoesNotProduceEmptySpans(): dd/dt only map to P when
+     * they wrap inline/text content directly. dd takes HTML flow content, so it
+     * can also directly contain block-level children (e.g. <dd><p>, <dd><ul>,
+     * <dd><table>) - for that case dd must stay Div, since Div (a Grouping
+     * element) legally contains other structure elements like P/L/Table, while
+     * P containing another P/L/Table would not be a sensible nesting. See
+     * review discussion on https://github.com/openhtmltopdf/openhtmltopdf/issues/100
+     */
+    @Test
+    public void testDdWithBlockContentStaysDiv() throws IOException {
+        String html =
+            "<html lang='en-US'><head>" +
+            "<title>DD block content test</title>" +
+            "<meta name='description' content='Regression test for issue 100 review comment'/>" +
+            "<style>" +
+            "body { margin: 0; font-family: 'TestFont'; font-size: 12px; }" +
+            "</style></head><body>" +
+            "<dl><dt>Foo</dt><dd><p>Bar</p><p>Baz</p></dd></dl>" +
+            "</body></html>";
+
+        ByteArrayOutputStream actual = new ByteArrayOutputStream();
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.withHtmlContent(html, null);
+        builder.toStream(actual);
+        builder.testMode(true);
+        builder.usePdfUaAccessibility(true);
+        builder.useFont(() -> NonVisualRegressionTest.class.getClassLoader().getResourceAsStream(
+            "org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"), "TestFont");
+        builder.run();
+
+        try (PDDocument doc = Loader.loadPDF(actual.toByteArray())) {
+            PDStructureTreeRoot root = doc.getDocumentCatalog().getStructureTreeRoot();
+
+            // The dd wrapping block content must still be Div (not P), and it
+            // must directly contain the two <p>s as legal Div>P nesting - not
+            // have any marked content of its own. Other Divs may legitimately
+            // exist in the tree (the <dl> itself also falls through to Div),
+            // so look for the specific one with exactly two direct, non-empty
+            // P children rather than asserting a total Div count.
+            List<PDStructureElement> divs = new ArrayList<>();
+            collectStructureElementsByType(root, "Div", divs);
+            assertFalse("Expected at least one Div in the tree (the dd's, at minimum)", divs.isEmpty());
+
+            PDStructureElement ddDiv = null;
+            for (PDStructureElement div : divs) {
+                List<PDStructureElement> directParagraphs = new ArrayList<>();
+                for (Object kid : div.getKids()) {
+                    if (kid instanceof PDStructureElement &&
+                        "P".equals(((PDStructureElement) kid).getStructureType())) {
+                        directParagraphs.add((PDStructureElement) kid);
+                    }
+                }
+                if (directParagraphs.size() == 2) {
+                    ddDiv = div;
+                    break;
+                }
+            }
+            assertNotNull(
+                "Should find a Div directly containing exactly two P elements " +
+                "(the block-content dd wrapping its two <p>s)", ddDiv);
+
+            List<PDStructureElement> paragraphs = new ArrayList<>();
+            collectStructureElementsByType(ddDiv, "P", paragraphs);
+            assertEquals("The dd's Div should directly contain both <p>s", 2, paragraphs.size());
+
+            for (Object kid : ddDiv.getKids()) {
+                assertFalse("The block-content dd's Div must not directly contain marked content",
+                    kid instanceof Integer || kid instanceof PDMarkedContentReference);
             }
         }
     }

--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/PdfUaTestcaseRunnerTest.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/testcases/PdfUaTestcaseRunnerTest.java
@@ -118,4 +118,17 @@ public class PdfUaTestcaseRunnerTest {
     public void testLinks() throws Exception {
         run("links");
     }
+
+    /**
+     * A dl/dd list where a dd contains a forced line break (br).
+     * The br (and its generated line-break content) must not be tagged
+     * as a Span structure element, which previously caused
+     * "possibly inappropriate use of a Span structure element" warnings
+     * in PDF/UA checkers such as PAC.
+     * See: https://github.com/openhtmltopdf/openhtmltopdf/issues/100
+     */
+    @Test
+    public void testDdWithBr() throws Exception {
+        run("dd-with-br");
+    }
 }

--- a/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
+++ b/openhtmltopdf-pdfbox/src/main/java/com/openhtmltopdf/pdfboxout/PdfBoxAccessibilityHelper.java
@@ -246,6 +246,39 @@ public class PdfBoxAccessibilityHelper {
                         // inline-block div, producing Span containing P which
                         // PAC flags as inappropriate use of Span.
                         return StandardStructureTypes.DIV;
+                    case "dt": // Fall-thru
+                    case "dd":
+                        // dd takes HTML flow content, so it can directly contain
+                        // block-level children (<dd><p>, <dd><ul>, <dd><table>, ...).
+                        // For that case Div is correct and already legal - Div is a
+                        // Grouping element and BLSEs like P/L/Table nest inside a
+                        // Grouping element just fine (Div>P, Div>L, Div>Table).
+                        //
+                        // It's only when dt/dd directly wraps inline/text content
+                        // that Div becomes a problem: falling through to Div (a
+                        // Grouping element that must not directly contain marked
+                        // content) forces the single-child collapse in finish() to
+                        // either violate that rule (raw content directly in the Div,
+                        // PAC: "Marked content is present in a possibly inadmissible
+                        // location") or wrap the content in a Span purely to satisfy
+                        // nesting, which PAC then flags right back as "possibly
+                        // inappropriate use of a Span structure element" since the
+                        // Span itself distinguishes nothing. So only map to P (a
+                        // content-permitting block-level element) in that inline
+                        // case; for block content, keep falling through to Div.
+                        //
+                        // There's no dedicated standard structure type for
+                        // definition-list terms/descriptions in PDF 1.7; PDF 2.0
+                        // supports L/LI/Lbl/LBody with ListNumbering=Description
+                        // for this (see PDF Association's "Deriving HTML from
+                        // PDF" spec, 4.3.5.5.2), which would be a more faithful
+                        // mapping but requires pairing sibling dt/dd elements
+                        // into synthetic LI groups - a larger, separate change.
+                        if (box instanceof BlockBox &&
+                            ((BlockBox) box).getChildrenContentType() == BlockBox.ContentType.INLINE) {
+                            return StandardStructureTypes.P;
+                        }
+                        break; // block content (or empty/unknown): fall through to Div below.
                     }
                 }
 
@@ -255,7 +288,29 @@ public class PdfBoxAccessibilityHelper {
             return StandardStructureTypes.SPAN;
         }
 
-        @Override
+    /**
+     * Counts children that are not themselves purely br-generated content.
+     * A br-generated child (see isBrGeneratedContent) always ends up contributing
+     * zero real content once its own finish() runs - it is either fully empty
+     * (the invisible line-break text is now an Artifact, see startStructure/TEXT)
+     * or gets flattened away. Without this, such a child would still count
+     * towards child.children.size(), so a wrapper box like "Bar<br>" would be
+     * seen as having 2 children instead of 1 and miss the single-child collapse
+     * below, needlessly getting its own Span. See GH issue #100.
+     */
+    private static int countNonBrChildren(List<AbstractTreeItem> children) {
+        int count = 0;
+        for (AbstractTreeItem item : children) {
+            if (item instanceof GenericStructualElement &&
+                isBrGeneratedContent(((GenericStructualElement) item).box)) {
+                continue;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    @Override
         void finish(AbstractStructualElement parent) {
             // A structual element such as Div, Sect, p, etc
             // which contains other structual elements or content items (text).
@@ -271,11 +326,17 @@ public class PdfBoxAccessibilityHelper {
 
             if (child.box instanceof LineBox ||
                 (child.box instanceof InlineLayoutBox &&
-                 child.children.size() == 1 &&
-                 child.box.getParent() instanceof LineBox)) {
+                 countNonBrChildren(child.children) == 1 &&
+                 child.box.getParent() instanceof LineBox) ||
+                isBrGeneratedContent(child.box)) {
                 // We skip (don't create structure element) line boxes in the tree.
                 // We also skip the common case of a intermediary InlineLayoutBox between the 
                 // LineBox and a single InlineText.
+                // We also skip <br> elements and the anonymous inline box generated for
+                // their :before content (the forced line break itself). A <br> has no
+                // text-level semantic of its own, so tagging it (or its generated content)
+                // as a Span causes "possibly inappropriate use of a Span structure element"
+                // warnings in PDF/UA checkers such as PAC. See GH issue #100.
                 finishTreeItems(child.children, parent);
             } else {
                 createPdfStrucureElement(parent, child);
@@ -910,6 +971,24 @@ public class PdfBoxAccessibilityHelper {
         _od.getWriter().getDocumentCatalog().getStructureTreeRoot().setParentTree(numberTreeNode);
     }
 
+    /**
+     * True if this box is a &lt;br&gt; element's layout box, or the anonymous inline box
+     * generated for its <code>:before</code> content (which is how forced line breaks are
+     * implemented, see <code>br:before</code> in the default stylesheet). Such boxes carry
+     * no visible text-level semantic of their own and should not become Span structure
+     * elements. Fixes https://github.com/openhtmltopdf/openhtmltopdf/issues/100
+     */
+    private static boolean isBrGeneratedContent(Box box) {
+        if (box.getElement() != null) {
+            return "br".equals(box.getElement().getTagName());
+        }
+
+        Box parent = box.getParent();
+        return parent != null &&
+               parent.getElement() != null &&
+               "br".equals(parent.getElement().getTagName());
+    }
+
     private static String guessBoxTag(Box box) {
         if (box instanceof BlockBox) {
             BlockBox block = (BlockBox) box;
@@ -1339,6 +1418,15 @@ public class PdfBoxAccessibilityHelper {
         return dict;
     }
 
+    private COSDictionary createLineBreakArtifact() {
+        // "Layout" is one of the standard Artifact Type values (PDF32000-1, 14.8.2.2.2)
+        // for content that is part of the page layout but not real, taggable content -
+        // which is exactly what a <br>'s generated line-break content is.
+        COSDictionary dict = new COSDictionary();
+        dict.setItem(COSName.TYPE, COSName.getPDFName("Layout"));
+        return dict;
+    }
+
     private static class Token {
     }
 
@@ -1431,6 +1519,18 @@ public class PdfBoxAccessibilityHelper {
                 return TRUE_TOKEN;
             }
             case TEXT: {
+                if (isBrGeneratedContent(box)) {
+                    // A <br>'s own box, and the invisible box generated for its :before
+                    // content implementing the forced line break, have no real text-level
+                    // content. Marking them as Span content (as we did before) produced a
+                    // /Span <</MCID n>> BDC immediately followed by EMC with nothing drawn
+                    // in between, which PDF/UA checkers flag as an inappropriate/empty
+                    // Span. Mark it as a Layout artifact instead - no MCID, no structure
+                    // element, entirely excluded from the tag tree. See GH issue #100.
+                    COSDictionary artifact = createLineBreakArtifact();
+                    _cs.beginMarkedContent(COSName.ARTIFACT, artifact);
+                    return TRUE_TOKEN;
+                }
                 GenericContentItem current = createMarkedContentStructureItem(type, box);
                 _cs.beginMarkedContent(COSName.getPDFName(StandardStructureTypes.SPAN), current.dict);
                 return TRUE_TOKEN;


### PR DESCRIPTION
## What does this change?

Fixes #100 - `<br>` in `<dd>` (or any inline context) causes PDF/UA validation warnings.

`<br>` is implemented via the default stylesheet as generated content
(`br:before { content: "\A"; white-space: pre-line; }`). Because
`PdfBoxAccessibilityHelper#chooseTag()` has no special case for `br`, both the
`<br>` element's own box and the anonymous box generated for its `:before`
content fell through to `guessBoxTag()`, which tags any inline box as `Span`.
That produced 2-3 nested `Span` structure elements per `<br>` - one of them
completely empty - which is exactly what PAC 2021 flags as "possibly
inappropriate use of a Span structure element".

The fix adds `isBrGeneratedContent(Box)` and extends the existing
"skip, don't create a structure element" branch in
`GenericStructualElement#finish()` (the same branch that already skips
`LineBox`es and single-child wrapper boxes) to also skip `<br>` and its
generated content. A `<br>` is formatting, not content, so it shouldn't
appear in the tag tree at all.

Verified end-to-end locally (built `openhtmltopdf-core` + `openhtmltopdf-pdfbox`
against PDFBox 3.0.7 - built from the official `apache/pdfbox` mirror since
Maven Central wasn't reachable in my sandbox): rendering
`<dl><dt>Foo</dt><dd>Bar<br>Baz</dd></dl>` with PDF/UA enabled produces 7
structure nodes / 2 `Span`s (both wrapping real text) after the fix, vs. 10
structure nodes / 5 `Span`s (including one entirely empty one) on `main`
(`e473ecf5`) before it.

Included:
- The fix itself in `PdfBoxAccessibilityHelper.java`.
- A new manual-PAC-confirmation testcase, `testcases/pdfua/dd-with-br.html` +
  `PdfUaTestcaseRunnerTest#testDdWithBr()`, following the project's existing
  pattern for PDF/UA testcases.
- A new automated regression test,
  `NonVisualRegressionTest#testBrInDdDoesNotProduceEmptySpans()`.
  This isn't a pixel-based visual regression test on purpose: the fix only
  changes the invisible `/Tags` tree, not the rendered page, so a pixel diff
  would pass identically before and after and wouldn't catch a regression.
  Instead it walks the actual structure tree via the PDFBox API (reusing the
  existing `collectStructureTags`/`collectLinkStructureElements` pattern
  already used elsewhere in this file) and asserts no `Span` has zero MCID
  descendants, plus pins down the exact expected count (2) so a regression
  that reintroduces non-empty superfluous wrapping would also be caught.

One open point noted in the PR body: both remaining `Span`s wrap real visible
text (never just the line break alone), which seemed like a reasonable place
to stop. If PAC still flags something, the natural follow-up is excluding
`<br>`-only content from the existing "single real child" skip heuristic too.

## How was it written?

- [ ] Written by hand
- [] AI-assisted - I have read and understood every line
- [x] Largely AI-generated
- [ ] I can answer follow-up questions about how this change works

## How should we send you fixes?

- [ ] Push small fixes straight to my branch - I will see the commits and can object
- [x] Leave them as review comments and I will make the changes